### PR TITLE
[Idea] [WIP] Introduce ROLE_NEUMARK_TRADER

### DIFF
--- a/contracts/AccessControl/StandardRoles.sol
+++ b/contracts/AccessControl/StandardRoles.sol
@@ -3,5 +3,6 @@ pragma solidity 0.4.15;
 contract StandardRoles {
 
     // NOTE: Soldity somehow doesn't evaluate this compile time
-    bytes32 public constant ROLE_ACCESS_CONTROLER = keccak256("AccessControler");
+    // keccak256("AccessControler")
+    bytes32 internal constant ROLE_ACCESS_CONTROLER = 0x7af7af21646173497b2ebfbff756b8658939b80bf5ac6a438a408950d80d5086;
 }

--- a/contracts/AccessRoles.sol
+++ b/contracts/AccessRoles.sol
@@ -14,7 +14,7 @@ contract AccessRoles {
 
     bytes32 internal constant ROLE_NEUMARK_ISSUER = 0x921c3afa1f1fff707a785f953a1e197bd28c9c50e300424e015953cbf120c06c;
     bytes32 internal constant ROLE_NEUMARK_BURNER = 0x19ce331285f41739cd3362a3ec176edffe014311c0f8075834fdd19d6718e69f;
-    bytes32 internal constant ROLE_TRANSFER_ADMIN = 0xb6527e944caca3d151b1f94e49ac5e223142694860743e66164720e034ec9b19;
+    bytes32 internal constant ROLE_NEUMARK_TRADER = 0x9979f44caa8e6d8c266331a94aa07c2adc0ab2a9e4caf0110b879db60af2ed44;
     bytes32 internal constant ROLE_SNAPSHOT_CREATOR = 0x08c1785afc57f933523bc52583a72ce9e19b2241354e04dd86f41f887e3d8174;
 
     bytes32 internal constant ROLE_RECLAIMER = 0x0542bbd0c672578966dcc525b30aa16723bb042675554ac5b0362f86b6e97dc5;

--- a/contracts/AccessRoles.sol
+++ b/contracts/AccessRoles.sol
@@ -2,18 +2,22 @@ pragma solidity 0.4.15;
 
 contract AccessRoles {
 
+    // NOTE: All roles are set to the keccak256 hash of the
+    // CamelCased role name, i.e.
+    // ROLE_LOCKED_ACCOUNT_ADMIN = keccak256("LockedAccountAdmin")
+
     // may setup LockedAccount, change disbursal mechanism and set migration
-    bytes32 public constant ROLE_LOCKED_ACCOUNT_ADMIN = keccak256("LockedAccountAdmin");
+    bytes32 internal constant ROLE_LOCKED_ACCOUNT_ADMIN = 0x4675da546d2d92c5b86c4f726a9e61010dce91cccc2491ce6019e78b09d2572e;
 
     // may setup whitelists and abort whitelisting contract with curve rollback
-    bytes32 public constant ROLE_WHITELIST_ADMIN = keccak256("WhitelistAdmin");
+    bytes32 internal constant ROLE_WHITELIST_ADMIN = 0xaef456e7c864418e1d2a40d996ca4febf3a7e317fe3af5a7ea4dda59033bbe5c;
 
-    bytes32 public constant ROLE_NEUMARK_ISSUER = keccak256("NeumarkIssuer");
-    bytes32 public constant ROLE_NEUMARK_BURNER = keccak256("NeumarkBurner");
-    bytes32 public constant ROLE_TRANSFERS_ADMIN = keccak256("TransferAdmin");
-    bytes32 public constant ROLE_SNAPSHOT_CREATOR = keccak256("SnapshotCreator");
+    bytes32 internal constant ROLE_NEUMARK_ISSUER = 0x921c3afa1f1fff707a785f953a1e197bd28c9c50e300424e015953cbf120c06c;
+    bytes32 internal constant ROLE_NEUMARK_BURNER = 0x19ce331285f41739cd3362a3ec176edffe014311c0f8075834fdd19d6718e69f;
+    bytes32 internal constant ROLE_TRANSFER_ADMIN = 0xb6527e944caca3d151b1f94e49ac5e223142694860743e66164720e034ec9b19;
+    bytes32 internal constant ROLE_SNAPSHOT_CREATOR = 0x08c1785afc57f933523bc52583a72ce9e19b2241354e04dd86f41f887e3d8174;
 
-    bytes32 public constant ROLE_RECLAIMER = keccak256("Reclaimer");
+    bytes32 internal constant ROLE_RECLAIMER = 0x0542bbd0c672578966dcc525b30aa16723bb042675554ac5b0362f86b6e97dc5;
 
-    bytes32 public constant ROLE_FORK_ARBITER = keccak256("ForkArbiter");
+    bytes32 internal constant ROLE_FORK_ARBITER = 0x82e9340eaa1325512ef04d5e85a62cfe9ec74ecfe2973fa5b393ae327dcf43e0;
 }

--- a/contracts/Commitment/CommitmentBase.sol
+++ b/contracts/Commitment/CommitmentBase.sol
@@ -162,13 +162,8 @@ contract CommitmentBase is AccessControlled, TimeSource, Math, ITokenOffering, R
     {
         // distribute half half
         uint256 investorNeumarks = divRound(neumarks, neumarkRewardPlatformOperatorDivisor);
-        // @ remco is there a better way to distribute?
-        bool isEnabled = neumark.transferEnabled();
-        if (!isEnabled)
-            neumark.enableTransfer(true);
         require(neumark.transfer(investor, investorNeumarks));
         require(neumark.transfer(platformOperatorWallet, neumarks - investorNeumarks));
-        neumark.enableTransfer(isEnabled);
         return investorNeumarks;
     }
 

--- a/contracts/Commitment/PublicCommitment.sol
+++ b/contracts/Commitment/PublicCommitment.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.4.15;
 
 import "./CommitmentBase.sol";
+import "../AccessControl/RoleBasedAccessControl.sol";
 
 /// public capital commitment for general public
 contract PublicCommitment is CommitmentBase {
@@ -13,6 +14,13 @@ contract PublicCommitment is CommitmentBase {
     {
         // enable Neumark trading in token controller
         neumark.enableTransfer(true);
+        RoleBasedAccessControl(neumark.accessPolicy()).setUserRole(
+            RoleBasedAccessControl.EVERYONE,
+            ROLE_NEUMARK_TRADER,
+            neumark,
+            RoleBasedAccessControl.TriState.Allow
+        );
+
         // enable escape hatch and end locking funds phase
         lockedAccount.controllerSucceeded();
     }

--- a/contracts/Neumark.sol
+++ b/contracts/Neumark.sol
@@ -20,7 +20,6 @@ contract Neumark is
     uint8  constant TOKEN_DECIMALS = 18;
     string constant TOKEN_SYMBOL   = "NMK";
 
-    bool public transferEnabled;
     uint256 public totalEuroUlps;
 
     event NeumarksIssued(
@@ -49,7 +48,6 @@ contract Neumark is
         NeumarkIssuanceCurve()
         Reclaimable()
     {
-        transferEnabled = false;
         totalEuroUlps = 0;
     }
 
@@ -88,13 +86,6 @@ contract Neumark is
         return euroUlps;
     }
 
-    function enableTransfer(bool enabled)
-        public
-        only(ROLE_TRANSFER_ADMIN)
-    {
-        transferEnabled = enabled;
-    }
-
     function createSnapshot()
         public
         only(ROLE_SNAPSHOT_CREATOR)
@@ -115,11 +106,12 @@ contract Neumark is
         uint amount
     )
         internal
+        only(ROLE_NEUMARK_TRADER)
         acceptAgreement(from)
         acceptAgreement(to)
         returns (bool allow)
     {
-        return transferEnabled;
+        return true;
     }
 
     /// @notice Notifies the controller about an approval allowing the

--- a/contracts/Neumark.sol
+++ b/contracts/Neumark.sol
@@ -90,7 +90,7 @@ contract Neumark is
 
     function enableTransfer(bool enabled)
         public
-        only(ROLE_TRANSFERS_ADMIN)
+        only(ROLE_TRANSFER_ADMIN)
     {
         transferEnabled = enabled;
     }

--- a/contracts/test/TestAccessControl.sol
+++ b/contracts/test/TestAccessControl.sol
@@ -5,8 +5,8 @@ import '../AccessControl/RoleBasedAccessControl.sol';
 
 contract TestAccessControlExampleRoles {
 
-    bytes32 public constant ROLE_EXAMPLE = keccak256("Owner");
-
+    // keccak256("Example")
+    bytes32 internal constant ROLE_EXAMPLE = 0xb01f6215887f913abe74277c39da2c7de51baf17958191658f84959dfddab970;
 }
 
 contract TestAccessControl is AccessControlled, TestAccessControlExampleRoles {

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,7 +1,6 @@
 require("babel-register");
 
 const RoleBasedAccessControl = artifacts.require("RoleBasedAccessControl");
-const AccessRoles = artifacts.require("AccessRoles");
 const EthereumForkArbiter = artifacts.require("EthereumForkArbiter");
 const Neumark = artifacts.require("Neumark");
 const LockedAccount = artifacts.require("LockedAccount");
@@ -75,35 +74,33 @@ module.exports = function deployContracts(deployer, network, accounts) {
     );
     console.log("Commitment terms set");
     console.log("Seting permissions");
-    await deployer.deploy(AccessRoles);
-    const accessRoles = await AccessRoles.deployed();
     await accessControl.setUserRole(
       publicCommitment.address,
-      await accessRoles.ROLE_NEUMARK_ISSUER(),
+      web3.sha3("NeumarkIssuer"),
       neumark.address,
       TriState.Allow
     );
     await accessControl.setUserRole(
       EVERYONE,
-      await accessRoles.ROLE_NEUMARK_BURNER(),
+      web3.sha3("NeumarkBurner"),
       neumark.address,
       TriState.Allow
     );
     await accessControl.setUserRole(
       EVERYONE,
-      await accessRoles.ROLE_SNAPSHOT_CREATOR(),
+      web3.sha3("SnapshotCreator"),
       neumark.address,
       TriState.Allow
     );
     await accessControl.setUserRole(
       publicCommitment.address,
-      await accessRoles.ROLE_TRANSFERS_ADMIN(),
+      web3.sha3("TransfersAdmin"),
       neumark.address,
       TriState.Allow
     );
     await accessControl.setUserRole(
       lockedAccountAdmin,
-      await accessRoles.ROLE_LOCKED_ACCOUNT_ADMIN(),
+      web3.sha3("LockedAccountAdmin"),
       lock.address,
       TriState.Allow
     );
@@ -112,7 +109,7 @@ module.exports = function deployContracts(deployer, network, accounts) {
     });
     await accessControl.setUserRole(
       whitelistAdmin,
-      await accessRoles.ROLE_WHITELIST_ADMIN(),
+      web3.sha3("WhitelistAdmin"),
       PublicCommitment.address,
       TriState.Allow
     );

--- a/test/AccessControl.js
+++ b/test/AccessControl.js
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import EvmError from "./helpers/EVMThrow";
 import { eventValue } from "./helpers/events";
 import { TriState } from "./helpers/triState";
+import roles from "./helpers/roles";
 
 const RoleBasedAccessControl = artifacts.require("RoleBasedAccessControl");
 const TestAccessControlTruffleMixin = artifacts.require(
@@ -19,7 +20,7 @@ contract("AccessControl", ([accessController, owner1, owner2]) => {
       accessControl.address
     );
 
-    exampleRole = web3.sha3("Example");
+    exampleRole = roles.example;
   });
 
   function expectAccessChangedEvent(

--- a/test/AccessControl.js
+++ b/test/AccessControl.js
@@ -19,7 +19,7 @@ contract("AccessControl", ([accessController, owner1, owner2]) => {
       accessControl.address
     );
 
-    exampleRole = await accessControlled.ROLE_EXAMPLE();
+    exampleRole = web3.sha3("Example");
   });
 
   function expectAccessChangedEvent(

--- a/test/EthereumForkArbiter.js
+++ b/test/EthereumForkArbiter.js
@@ -10,7 +10,7 @@ contract("EthereumForkArbiter", ([deployer, arbiter, other]) => {
 
   beforeEach(async () => {
     const accessPolicy = await createAccessPolicy([
-      { subject: arbiter, role: "ROLE_FORK_ARBITER" }
+      { subject: arbiter, role: "ForkArbiter" }
     ]);
     ethereumForkArbiter = await EthereumForkArbiter.new(accessPolicy);
   });

--- a/test/EthereumForkArbiter.js
+++ b/test/EthereumForkArbiter.js
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { prettyPrintGasCost } from "./helpers/gasUtils";
 import createAccessPolicy from "./helpers/createAccessPolicy";
 import { eventValue } from "./helpers/events";
+import roles from "./helpers/roles";
 
 const EthereumForkArbiter = artifacts.require("EthereumForkArbiter");
 
@@ -10,7 +11,7 @@ contract("EthereumForkArbiter", ([deployer, arbiter, other]) => {
 
   beforeEach(async () => {
     const accessPolicy = await createAccessPolicy([
-      { subject: arbiter, role: "ForkArbiter" }
+      { subject: arbiter, role: roles.forkArbiter }
     ]);
     ethereumForkArbiter = await EthereumForkArbiter.new(accessPolicy);
   });

--- a/test/LockedAccountMigration.js
+++ b/test/LockedAccountMigration.js
@@ -34,10 +34,9 @@ contract("TestLockedAccountMigrationTarget", ([admin, investor, investor2]) => {
       18 * chain.months,
       chain.ether(1).mul(0.1).round()
     );
-    const lockedAccountAdminRole = await chain.accessRoles.ROLE_LOCKED_ACCOUNT_ADMIN();
     await chain.accessControl.setUserRole(
       admin,
-      lockedAccountAdminRole,
+      web3.sha3("LockedAccountAdmin"),
       migrationTarget.address,
       1
     );

--- a/test/LockedAccountMigration.js
+++ b/test/LockedAccountMigration.js
@@ -3,6 +3,7 @@ import { hasEvent, eventValue } from "./helpers/events";
 import * as chain from "./helpers/spawnContracts";
 import { latestTimestamp } from "./helpers/latestTime";
 import EvmError from "./helpers/EVMThrow";
+import roles from "./helpers/roles";
 
 const TestLockedAccountMigrationTarget = artifacts.require(
   "TestLockedAccountMigrationTarget"
@@ -36,7 +37,7 @@ contract("TestLockedAccountMigrationTarget", ([admin, investor, investor2]) => {
     );
     await chain.accessControl.setUserRole(
       admin,
-      web3.sha3("LockedAccountAdmin"),
+      roles.lockedAccountAdmin,
       migrationTarget.address,
       1
     );

--- a/test/Neumark.js
+++ b/test/Neumark.js
@@ -19,7 +19,7 @@ contract("Neumark", accounts => {
 
   beforeEach(async () => {
     rbac = await createAccessPolicy([
-      { subject: accounts[0], role: roles.transferAdmin },
+      { role: roles.neumarkTrader },
       { subject: accounts[0], role: roles.neumarkIssuer },
       { subject: accounts[1], role: roles.neumarkIssuer },
       { subject: accounts[2], role: roles.neumarkIssuer },

--- a/test/Neumark.js
+++ b/test/Neumark.js
@@ -18,12 +18,12 @@ contract("Neumark", accounts => {
 
   beforeEach(async () => {
     rbac = await createAccessPolicy([
-      { subject: accounts[0], role: "ROLE_TRANSFERS_ADMIN" },
-      { subject: accounts[0], role: "ROLE_NEUMARK_ISSUER" },
-      { subject: accounts[1], role: "ROLE_NEUMARK_ISSUER" },
-      { subject: accounts[2], role: "ROLE_NEUMARK_ISSUER" },
-      { subject: accounts[0], role: "ROLE_NEUMARK_BURNER" },
-      { subject: accounts[1], role: "ROLE_NEUMARK_BURNER" }
+      { subject: accounts[0], role: "TransferAdmin" },
+      { subject: accounts[0], role: "NeumarkIssuer" },
+      { subject: accounts[1], role: "NeumarkIssuer" },
+      { subject: accounts[2], role: "NeumarkIssuer" },
+      { subject: accounts[0], role: "NeumarkBurner" },
+      { subject: accounts[1], role: "NeumarkBurner" }
     ]);
     forkArbiter = await EthereumForkArbiter.new(rbac);
     neumark = await Neumark.new(rbac, forkArbiter.address, agreementUri);

--- a/test/Neumark.js
+++ b/test/Neumark.js
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { prettyPrintGasCost } from "./helpers/gasUtils";
 import { eventValue } from "./helpers/events";
 import createAccessPolicy from "./helpers/createAccessPolicy";
+import roles from "./helpers/roles";
 
 const EthereumForkArbiter = artifacts.require("EthereumForkArbiter");
 const Neumark = artifacts.require("./Neumark.sol");
@@ -18,12 +19,12 @@ contract("Neumark", accounts => {
 
   beforeEach(async () => {
     rbac = await createAccessPolicy([
-      { subject: accounts[0], role: "TransferAdmin" },
-      { subject: accounts[0], role: "NeumarkIssuer" },
-      { subject: accounts[1], role: "NeumarkIssuer" },
-      { subject: accounts[2], role: "NeumarkIssuer" },
-      { subject: accounts[0], role: "NeumarkBurner" },
-      { subject: accounts[1], role: "NeumarkBurner" }
+      { subject: accounts[0], role: roles.transferAdmin },
+      { subject: accounts[0], role: roles.neumarkIssuer },
+      { subject: accounts[1], role: roles.neumarkIssuer },
+      { subject: accounts[2], role: roles.neumarkIssuer },
+      { subject: accounts[0], role: roles.neumarkBurner },
+      { subject: accounts[1], role: roles.neumarkBurner }
     ]);
     forkArbiter = await EthereumForkArbiter.new(rbac);
     neumark = await Neumark.new(rbac, forkArbiter.address, agreementUri);

--- a/test/Reclaimable.js
+++ b/test/Reclaimable.js
@@ -11,7 +11,7 @@ contract("Reclaimable", ([deployer, reclaimer, other]) => {
 
   beforeEach(async () => {
     const accessPolicy = await createAccessPolicy([
-      { subject: reclaimer, role: "ROLE_RECLAIMER" }
+      { subject: reclaimer, role: "Reclaimer" }
     ]);
     reclaimable = await TestReclaimable.new(accessPolicy);
     RECLAIM_ETHER = await reclaimable.RECLAIM_ETHER();

--- a/test/Reclaimable.js
+++ b/test/Reclaimable.js
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import createAccessPolicy from "./helpers/createAccessPolicy";
 import forceEther from "./helpers/forceEther";
+import roles from "./helpers/roles";
 
 const TestReclaimable = artifacts.require("TestReclaimable");
 const TestToken = artifacts.require("TestToken");
@@ -11,7 +12,7 @@ contract("Reclaimable", ([deployer, reclaimer, other]) => {
 
   beforeEach(async () => {
     const accessPolicy = await createAccessPolicy([
-      { subject: reclaimer, role: "Reclaimer" }
+      { subject: reclaimer, role: roles.reclaimer }
     ]);
     reclaimable = await TestReclaimable.new(accessPolicy);
     RECLAIM_ETHER = await reclaimable.RECLAIM_ETHER();

--- a/test/helpers/createAccessPolicy.js
+++ b/test/helpers/createAccessPolicy.js
@@ -3,11 +3,9 @@ import { TriState, EVERYONE, GLOBAL } from "./triState";
 const RoleBasedAccessControl = artifacts.require(
   "./AccessControl/RoleBasedAccessControl.sol"
 );
-const AccessRoles = artifacts.require("./AccessRoles");
 
 export default async roles => {
   const rbac = await RoleBasedAccessControl.new();
-  const accessRoles = await AccessRoles.new();
   await Promise.all(
     roles.map(async policy => {
       const { subject, role, object, state } = Object.assign(
@@ -18,7 +16,7 @@ export default async roles => {
         },
         policy
       );
-      const roleHash = await accessRoles[role]();
+      const roleHash = web3.sha3(role);
       await rbac.setUserRole(subject, roleHash, object, state);
     })
   );

--- a/test/helpers/createAccessPolicy.js
+++ b/test/helpers/createAccessPolicy.js
@@ -16,8 +16,7 @@ export default async roles => {
         },
         policy
       );
-      const roleHash = web3.sha3(role);
-      await rbac.setUserRole(subject, roleHash, object, state);
+      await rbac.setUserRole(subject, role, object, state);
     })
   );
   return rbac.address;

--- a/test/helpers/deploy.js
+++ b/test/helpers/deploy.js
@@ -9,7 +9,6 @@ const Neumark = artifacts.require("Neumark");
 const WhitelistedCommitment = artifacts.require("WhitelistedCommitment");
 const RoleBasedAccessControl = artifacts.require("RoleBasedAccessControl");
 const EthereumForkArbiter = artifacts.require("EthereumForkArbiter");
-const AccessRoles = artifacts.require("AccessRoles");
 
 export default async function deploy(
   lockAdminAccount,
@@ -36,7 +35,6 @@ export default async function deploy(
   } = commitmentCfg;
 
   const accessControl = await RoleBasedAccessControl.new();
-  const accessRoles = await AccessRoles.new();
   const forkArbiter = await EthereumForkArbiter.new(accessControl.address);
   const etherToken = await EtherToken.new(accessControl.address);
   const neumark = await Neumark.new(
@@ -54,10 +52,9 @@ export default async function deploy(
     unlockDateMonths * MONTH,
     etherToWei(1).mul(unlockPenalty).round()
   );
-  const lockedAccountAdminRole = await accessRoles.ROLE_LOCKED_ACCOUNT_ADMIN();
   await accessControl.setUserRole(
     lockAdminAccount,
-    lockedAccountAdminRole,
+    web3.sha3("LockedAccountAdmin"),
     lockedAccount.address,
     TriState.Allow
   );
@@ -67,13 +64,13 @@ export default async function deploy(
 
   await accessControl.setUserRole(
     EVERYONE,
-    await accessRoles.ROLE_NEUMARK_BURNER(),
+    web3.sha3("NeumarkBurner"),
     neumark.address,
     TriState.Allow
   );
   await accessControl.setUserRole(
     EVERYONE,
-    await accessRoles.ROLE_SNAPSHOT_CREATOR(),
+    web3.sha3("SnapshotCreator"),
     neumark.address,
     TriState.Allow
   );
@@ -95,21 +92,20 @@ export default async function deploy(
   );
   await accessControl.setUserRole(
     commitment.address,
-    await accessRoles.ROLE_NEUMARK_ISSUER(),
+    web3.sha3("NeumarkIssuer"),
     neumark.address,
     TriState.Allow
   );
   await accessControl.setUserRole(
     commitment.address,
-    await accessRoles.ROLE_TRANSFERS_ADMIN(),
+    web3.sha3("TransferAdmin"),
     neumark.address,
     TriState.Allow
   );
 
-  const whitelistAdminRole = await accessRoles.ROLE_WHITELIST_ADMIN();
   await accessControl.setUserRole(
     whitelistAdminAccount,
-    whitelistAdminRole,
+    web3.sha3("WhitelistAdmin"),
     commitment.address,
     TriState.Allow
   );

--- a/test/helpers/deploy.js
+++ b/test/helpers/deploy.js
@@ -2,6 +2,7 @@ import invariant from "invariant";
 import { MONTH, closeFutureDate } from "./latestTime";
 import { etherToWei } from "./unitConverter";
 import { TriState, EVERYONE } from "./triState";
+import roles from "./roles";
 
 const LockedAccount = artifacts.require("LockedAccount");
 const EtherToken = artifacts.require("EtherToken");
@@ -54,7 +55,7 @@ export default async function deploy(
   );
   await accessControl.setUserRole(
     lockAdminAccount,
-    web3.sha3("LockedAccountAdmin"),
+    roles.lockedAccountAdmin,
     lockedAccount.address,
     TriState.Allow
   );
@@ -64,13 +65,13 @@ export default async function deploy(
 
   await accessControl.setUserRole(
     EVERYONE,
-    web3.sha3("NeumarkBurner"),
+    roles.neumarkBurner,
     neumark.address,
     TriState.Allow
   );
   await accessControl.setUserRole(
     EVERYONE,
-    web3.sha3("SnapshotCreator"),
+    roles.snapshotCreator,
     neumark.address,
     TriState.Allow
   );
@@ -92,20 +93,20 @@ export default async function deploy(
   );
   await accessControl.setUserRole(
     commitment.address,
-    web3.sha3("NeumarkIssuer"),
+    roles.neumarkIssuer,
     neumark.address,
     TriState.Allow
   );
   await accessControl.setUserRole(
     commitment.address,
-    web3.sha3("TransferAdmin"),
+    roles.transferAdmin,
     neumark.address,
     TriState.Allow
   );
 
   await accessControl.setUserRole(
     whitelistAdminAccount,
-    web3.sha3("WhitelistAdmin"),
+    roles.whitelistAdmin,
     commitment.address,
     TriState.Allow
   );

--- a/test/helpers/roles.js
+++ b/test/helpers/roles.js
@@ -5,6 +5,7 @@ export default {
   lockedAccountAdmin: web3.sha3("LockedAccountAdmin"),
   neumarkBurner: web3.sha3("NeumarkBurner"),
   neumarkIssuer: web3.sha3("NeumarkIssuer"),
+  neumarkTrader: web3.sha3("NeumarkTrader"),
   reclaimer: web3.sha3("Reclaimer"),
   snapshotCreator: web3.sha3("SnapshotCreator"),
   transferAdmin: web3.sha3("TransferAdmin"),

--- a/test/helpers/roles.js
+++ b/test/helpers/roles.js
@@ -1,0 +1,12 @@
+export default {
+  accessController: web3.sha3("AccessController"),
+  example: web3.sha3("Example"),
+  forkArbiter: web3.sha3("ForkArbiter"),
+  lockedAccountAdmin: web3.sha3("LockedAccountAdmin"),
+  neumarkBurner: web3.sha3("NeumarkBurner"),
+  neumarkIssuer: web3.sha3("NeumarkIssuer"),
+  reclaimer: web3.sha3("Reclaimer"),
+  snapshotCreator: web3.sha3("SnapshotCreator"),
+  transferAdmin: web3.sha3("TransferAdmin"),
+  whitelistAdmin: web3.sha3("WhitelistAdmin")
+};

--- a/test/helpers/spawnContracts.js
+++ b/test/helpers/spawnContracts.js
@@ -1,4 +1,5 @@
 import { TriState, EVERYONE } from "./triState";
+import roles from "./roles";
 
 const LockedAccount = artifacts.require("LockedAccount");
 const EtherToken = artifacts.require("EtherToken");
@@ -52,7 +53,7 @@ export async function spawnLockedAccount(
   );
   await accessControl.setUserRole(
     lockAdminAccount,
-    web3.sha3("LockedAccountAdmin"),
+    roles.lockedAccountAdmin,
     lockedAccount.address,
     TriState.Allow
   );
@@ -63,25 +64,25 @@ export async function spawnLockedAccount(
   // TODO: Restrict to correct spawened contracts
   await accessControl.setUserRole(
     EVERYONE,
-    web3.sha3("SnapshotCreator"),
+    roles.snapshotCreator,
     neumark.address,
     TriState.Allow
   );
   await accessControl.setUserRole(
     EVERYONE,
-    web3.sha3("NeumarkIssuer"),
+    roles.neumarkIssuer,
     neumark.address,
     TriState.Allow
   );
   await accessControl.setUserRole(
     EVERYONE,
-    web3.sha3("NeumarkBurner"),
+    roles.neumarkBurner,
     neumark.address,
     TriState.Allow
   );
   await accessControl.setUserRole(
     EVERYONE,
-    web3.sha3("TransferAdmin"),
+    roles.transferAdmin,
     neumark.address,
     TriState.Allow
   );
@@ -145,7 +146,7 @@ export async function spawnWhitelistedCommitment(
   // console.log(lockedAccount.setController);
   await accessControl.setUserRole(
     whitelistAdminAccount,
-    web3.sha3("WhitelistAdmin"),
+    roles.whitelistAdmin,
     commitment.address,
     TriState.Allow
   );

--- a/test/helpers/spawnContracts.js
+++ b/test/helpers/spawnContracts.js
@@ -7,7 +7,6 @@ const TestCommitment = artifacts.require("TestCommitment");
 const WhitelistedCommitment = artifacts.require("WhitelistedCommitment");
 const EthereumForkArbiter = artifacts.require("EthereumForkArbiter");
 const RoleBasedAccessControl = artifacts.require("RoleBasedAccessControl");
-const AccessRoles = artifacts.require("AccessRoles");
 
 const BigNumber = web3.BigNumber;
 
@@ -19,7 +18,6 @@ export let curve;
 export let commitment;
 export let feePool;
 export let accessControl;
-export let accessRoles;
 export let forkArbiter;
 
 /* eslint-enable */
@@ -35,7 +33,6 @@ export async function spawnLockedAccount(
   unlockPenalty
 ) {
   accessControl = await RoleBasedAccessControl.new();
-  accessRoles = await AccessRoles.new();
   forkArbiter = await EthereumForkArbiter.new(accessControl.address);
   etherToken = await EtherToken.new(accessControl.address);
   // console.log(`\tEtherToken took ${gasCost(etherToken)}.`);
@@ -53,10 +50,9 @@ export async function spawnLockedAccount(
     unlockDateMonths * months,
     ether(1).mul(unlockPenalty).round()
   );
-  const lockedAccountAdminRole = await accessRoles.ROLE_LOCKED_ACCOUNT_ADMIN();
   await accessControl.setUserRole(
     lockAdminAccount,
-    lockedAccountAdminRole,
+    web3.sha3("LockedAccountAdmin"),
     lockedAccount.address,
     TriState.Allow
   );
@@ -67,25 +63,25 @@ export async function spawnLockedAccount(
   // TODO: Restrict to correct spawened contracts
   await accessControl.setUserRole(
     EVERYONE,
-    await accessRoles.ROLE_SNAPSHOT_CREATOR(),
+    web3.sha3("SnapshotCreator"),
     neumark.address,
     TriState.Allow
   );
   await accessControl.setUserRole(
     EVERYONE,
-    await accessRoles.ROLE_NEUMARK_ISSUER(),
+    web3.sha3("NeumarkIssuer"),
     neumark.address,
     TriState.Allow
   );
   await accessControl.setUserRole(
     EVERYONE,
-    await accessRoles.ROLE_NEUMARK_BURNER(),
+    web3.sha3("NeumarkBurner"),
     neumark.address,
     TriState.Allow
   );
   await accessControl.setUserRole(
     EVERYONE,
-    await accessRoles.ROLE_TRANSFERS_ADMIN(),
+    web3.sha3("TransferAdmin"),
     neumark.address,
     TriState.Allow
   );
@@ -147,10 +143,9 @@ export async function spawnWhitelistedCommitment(
     operatorWallet
   );
   // console.log(lockedAccount.setController);
-  const whitelistAdminRole = await accessRoles.ROLE_WHITELIST_ADMIN();
   await accessControl.setUserRole(
     whitelistAdminAccount,
-    whitelistAdminRole,
+    web3.sha3("WhitelistAdmin"),
     commitment.address,
     TriState.Allow
   );

--- a/test/helpers/verification.js
+++ b/test/helpers/verification.js
@@ -1,6 +1,7 @@
 import { etherToWei, DIGITS } from "./unitConverter";
 import { eventValue } from "./events";
 import { TriState, EVERYONE } from "./triState";
+import roles from "./roles";
 
 const RoleBasedAccessControl = artifacts.require("RoleBasedAccessControl");
 const EthereumForkArbiter = artifacts.require("EthereumForkArbiter");
@@ -18,19 +19,19 @@ async function deployNeumark() {
   // TODO: more specific rights
   await rbac.setUserRole(
     EVERYONE,
-    web3.sha3("NeumarkIssuer"),
+    roles.neumarkIssuer,
     neumark.address,
     TriState.Allow
   );
   await rbac.setUserRole(
     EVERYONE,
-    web3.sha3("NeumarkBurner"),
+    roles.neumarkBurner,
     neumark.address,
     TriState.Allow
   );
   await rbac.setUserRole(
     EVERYONE,
-    web3.sha3("TransferAdmin"),
+    roles.transferAdmin,
     neumark.address,
     TriState.Allow
   );

--- a/test/helpers/verification.js
+++ b/test/helpers/verification.js
@@ -3,13 +3,11 @@ import { eventValue } from "./events";
 import { TriState, EVERYONE } from "./triState";
 
 const RoleBasedAccessControl = artifacts.require("RoleBasedAccessControl");
-const AccessRoles = artifacts.require("AccessRoles");
 const EthereumForkArbiter = artifacts.require("EthereumForkArbiter");
 const Neumark = artifacts.require("Neumark");
 
 async function deployNeumark() {
   const rbac = await RoleBasedAccessControl.new();
-  const roles = await AccessRoles.new();
   const ethereumForkArbiter = await EthereumForkArbiter.new(rbac.address);
   const neumark = await Neumark.new(
     rbac.address,
@@ -20,19 +18,19 @@ async function deployNeumark() {
   // TODO: more specific rights
   await rbac.setUserRole(
     EVERYONE,
-    await roles.ROLE_NEUMARK_ISSUER(),
+    web3.sha3("NeumarkIssuer"),
     neumark.address,
     TriState.Allow
   );
   await rbac.setUserRole(
     EVERYONE,
-    await roles.ROLE_NEUMARK_BURNER(),
+    web3.sha3("NeumarkBurner"),
     neumark.address,
     TriState.Allow
   );
   await rbac.setUserRole(
     EVERYONE,
-    await roles.ROLE_TRANSFERS_ADMIN(),
+    web3.sha3("TransferAdmin"),
     neumark.address,
     TriState.Allow
   );


### PR DESCRIPTION
Here's an idea. We introduce a role NEUMARK_TRADER for the transfer function. We can then remove all of the transferEnabled / transferAdmin stuff and instead control it by setting (EVERYONE, ROLE_NEUMARK_TRADER, NEUMARK, Allow/Deny). We can give Commitment contracts special permission, so we can also remove the enableTransfer stuff there.

It both increases functionality and reduces code complexity. Only downside is that there won't be a TransferAdmin anymore, but intead this needs to be the AccessController.

(which can always be changed later by upgrading the accesspolicy)