### PR TITLE
Verify callback caller

### DIFF
--- a/contracts/LockedAccount.sol
+++ b/contracts/LockedAccount.sol
@@ -170,6 +170,7 @@ contract LockedAccount is
         public
         returns (bool)
     {
+        require(msg.sender == _token);
         require(_data.length == 0);
         // only from neumarks
         require(_token == address(neumark));

--- a/contracts/SnapshotToken/Extensions/Disbursal.sol
+++ b/contracts/SnapshotToken/Extensions/Disbursal.sol
@@ -197,6 +197,7 @@ contract Disbursal is IERC677Callback {
         public
         returns (bool)
     {
+        require(msg.sender == token);
         require(data.length == 0);
         disburseAllowance(IERC20Token(token), from, amount);
     }

--- a/contracts/Standards/IERC677Callback.sol
+++ b/contracts/Standards/IERC677Callback.sol
@@ -3,6 +3,9 @@ pragma solidity 0.4.15;
 
 contract IERC677Callback {
 
+    // NOTE: This call can be initiated by anyone. You need to make sure that
+    // it is send by the token (`require(msg.sender == token)`) or make sure
+    // amount is valid (`require(token.allowance(this) >= amount)`).
     function receiveApproval(
         address from,
         uint256 amount,

--- a/contracts/test/TestFeeDistributionPool.sol
+++ b/contracts/test/TestFeeDistributionPool.sol
@@ -12,6 +12,7 @@ contract TestFeeDistributionPool is IERC677Callback {
         public
         returns (bool)
     {
+        require(msg.sender == _token);
         require(IERC677Token(_token).transferFrom(from, address(this), _amount));
         TestReceiveApproval(from, _amount);
         return true;


### PR DESCRIPTION
Currently `LockedAccount` has an issue where in the state `ReleaseAll` it is possible to unlock for anyone (not just `msg.sender` as in `unlock()`) by calling the `receiveApproval` function. The root cause is that it does not verify being called by the token contract (trusting parameters instead). This PR adds explicit checks for callback origins.

It seems to have a minor impact but is certainly unintended behaviour. It effectively makes `unlockFor` a public function.