### PR TITLE
adds asset transfer to locked account migration

### DIFF
--- a/contracts/LockedAccount.sol
+++ b/contracts/LockedAccount.sol
@@ -285,10 +285,16 @@ contract LockedAccount is
         require(address(_migration) != 0);
 
         // migrates
-        Account storage a = _accounts[msg.sender];
+        Account memory a = _accounts[msg.sender];
 
         // if there is anything to migrate
         if (a.balance > 0) {
+
+            // this will clear investor storage
+            removeInvestor(msg.sender, a.balance);
+
+            // let migration target to own asset balance that belongs to investor
+            require(ASSET_TOKEN.approve(address(_migration), a.balance));
             bool migrated = _migration.migrateInvestor(
                 msg.sender,
                 a.balance,
@@ -297,7 +303,6 @@ contract LockedAccount is
             );
             assert(migrated);
             InvestorMigrated(msg.sender, a.balance, a.neumarksDue, a.unlockDate);
-            removeInvestor(msg.sender, a.balance);
         }
     }
 

--- a/contracts/test/TestLockedAccountMigrationTarget.sol
+++ b/contracts/test/TestLockedAccountMigrationTarget.sol
@@ -8,6 +8,12 @@ import '../Standards/IERC677Token.sol';
 contract TestLockedAccountMigrationTarget is LockedAccount, LockedAccountMigration {
 
     ////////////////////////
+    // Immutable state
+    ////////////////////////
+
+    IERC677Token private ASSET_TOKEN;
+
+    ////////////////////////
     // Mutable state
     ////////////////////////
 
@@ -30,6 +36,7 @@ contract TestLockedAccountMigrationTarget is LockedAccount, LockedAccountMigrati
     )
         LockedAccount(_policy, _forkArbiter, _agreementUri, _assetToken, _neumark, _lockPeriod, _penaltyFraction)
     {
+        ASSET_TOKEN = _assetToken;
     }
 
     ////////////////////////
@@ -57,7 +64,8 @@ contract TestLockedAccountMigrationTarget is LockedAccount, LockedAccountMigrati
     {
         if (_shouldMigrationFail)
             return false;
-
+        // transfer assets
+        require(ASSET_TOKEN.transferFrom(msg.sender, address(this), balance));
         // just move account
         _accounts[investor] = Account({
             balance: balance,

--- a/test/LockedAccountMigration.js
+++ b/test/LockedAccountMigration.js
@@ -9,162 +9,247 @@ const TestLockedAccountMigrationTarget = artifacts.require(
   "TestLockedAccountMigrationTarget"
 );
 
-contract("TestLockedAccountMigrationTarget", ([admin, investor, investor2]) => {
-  let startTimestamp;
-  let migrationTarget;
+// this low gas price is forced by code coverage
+const gasPrice = new web3.BigNumber(0x01);
 
-  beforeEach(async () => {
-    await chain.spawnLockedAccount(admin, 18, 0.1);
-    // achtung! latestTimestamp() must be called after a block is mined, before that time is not accurrate
-    startTimestamp = latestTimestamp();
-    await chain.spawnPublicCommitment(
-      admin,
-      startTimestamp,
-      chain.months,
-      chain.ether(1),
-      chain.ether(2000),
-      chain.ether(1),
-      300.1219871
-    );
-    migrationTarget = await TestLockedAccountMigrationTarget.new(
-      chain.accessControl.address,
-      chain.forkArbiter.address,
-      "ipfs:QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT",
-      chain.etherToken.address,
-      chain.neumark.address,
-      18 * chain.months,
-      chain.ether(1).mul(0.1).round()
-    );
-    await chain.accessControl.setUserRole(
-      admin,
-      roles.lockedAccountAdmin,
-      migrationTarget.address,
-      1
-    );
-  });
+contract(
+  "TestLockedAccountMigrationTarget",
+  ([_, admin, investor, investor2]) => {
+    let startTimestamp;
+    let migrationTarget;
+    let assetToken;
 
-  // it -> check in invalid states in enableMigration
+    async function deployMigrationTarget() {
+      const target = await TestLockedAccountMigrationTarget.new(
+        chain.accessControl.address,
+        chain.forkArbiter.address,
+        "ipfs:QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT",
+        assetToken.address,
+        chain.neumark.address,
+        18 * chain.months,
+        chain.ether(1).mul(0.1).round()
+      );
+      await chain.accessControl.setUserRole(
+        admin,
+        roles.lockedAccountAdmin,
+        target.address,
+        1
+      );
 
-  it("call migrate not from source should throw", async () => {
-    // this dummy setting should pass
-    await migrationTarget.setMigrationSource(investor2, { from: admin });
-    await migrationTarget.migrateInvestor(investor, 1, 1, startTimestamp, {
-      from: investor2
+      return target;
+    }
+
+    beforeEach(async () => {
+      await chain.spawnLockedAccount(admin, 18, 0.1);
+      // achtung! latestTimestamp() must be called after a block is mined, before that time is not accurrate
+      startTimestamp = latestTimestamp();
+      await chain.spawnPublicCommitment(
+        admin,
+        startTimestamp,
+        chain.months,
+        chain.ether(1),
+        chain.ether(2000),
+        chain.ether(1),
+        300.1219871
+      );
+      assetToken = chain.etherToken;
+      migrationTarget = await deployMigrationTarget();
     });
-    // this should not, only investor2 (which is source) can call migrate on target
-    await expect(
-      migrationTarget.migrateInvestor(investor, 1, 1, startTimestamp, {
+
+    // it -> check in invalid states in enableMigration
+
+    it("call migrate not from source should throw", async () => {
+      const ticket = 1; // 1 wei ticket
+      // test migration accepts any address
+      await migrationTarget.setMigrationSource(investor2, { from: admin });
+      // set allowance in asset token
+      await assetToken.deposit(investor2, ticket, {
+        from: admin,
+        value: ticket
+      });
+      await assetToken.approve(migrationTarget.address, 1, {
+        from: investor2
+      });
+      await migrationTarget.migrateInvestor(
+        investor,
+        ticket,
+        1,
+        startTimestamp,
+        {
+          from: investor2
+        }
+      );
+      // set allowances again
+      await assetToken.deposit(investor, ticket, {
+        from: admin,
+        value: ticket
+      });
+      await assetToken.approve(migrationTarget.address, ticket, {
         from: investor
-      })
-    ).to.be.rejectedWith(EvmError);
-  });
-
-  it("target that returns false on migration should throw", async () => {
-    const ticket = chain.ether(1);
-    const neumarks = ticket.mul(6.5);
-    // lock investor
-    await chain.commitment.investFor(investor, ticket, neumarks, {
-      value: ticket,
-      from: investor
-    });
-    await migrationTarget.setMigrationSource(chain.lockedAccount.address, {
-      from: admin
-    });
-    await chain.lockedAccount.enableMigration(migrationTarget.address, {
-      from: admin
+      });
+      // this should not, only investor2 (which is source) can call migrate on target
+      await expect(
+        migrationTarget.migrateInvestor(investor, ticket, 1, startTimestamp, {
+          from: investor
+        })
+      ).to.be.rejectedWith(EvmError);
     });
 
-    await migrationTarget.setShouldMigrationFail(true, { from: admin });
-    await expect(
-      chain.lockedAccount.migrate({ from: investor })
-    ).to.be.rejectedWith(EvmError);
-  });
+    it("target that returns false on migration should throw", async () => {
+      const ticket = chain.ether(1);
+      const neumarks = ticket.mul(6.5);
+      // lock investor
+      await chain.commitment.investFor(investor, ticket, neumarks, {
+        value: ticket,
+        from: investor
+      });
+      await migrationTarget.setMigrationSource(chain.lockedAccount.address, {
+        from: admin
+      });
+      await chain.lockedAccount.enableMigration(migrationTarget.address, {
+        from: admin
+      });
 
-  it("target with invalid source should throw", async () => {
-    // we set invalid source here
-    await migrationTarget.setMigrationSource(investor, { from: admin });
-    // accepts only lockedAccount as source
-    await expect(
-      chain.lockedAccount.enableMigration(migrationTarget.address)
-    ).to.be.rejectedWith(EvmError);
-  });
+      await migrationTarget.setShouldMigrationFail(true, { from: admin });
+      await expect(
+        chain.lockedAccount.migrate({ from: investor })
+      ).to.be.rejectedWith(EvmError);
+    });
 
-  async function migrateOne() {
-    const ticket = chain.ether(1);
-    const neumarks = ticket.mul(6.5);
-    // lock investor
-    await chain.commitment.investFor(investor, ticket, neumarks, {
-      value: ticket,
-      from: investor
+    it("target with invalid source should throw", async () => {
+      // we set invalid source here
+      await migrationTarget.setMigrationSource(investor, { from: admin });
+      // accepts only lockedAccount as source
+      await expect(
+        chain.lockedAccount.enableMigration(migrationTarget.address)
+      ).to.be.rejectedWith(EvmError);
     });
-    let investorBalance = await chain.lockedAccount.balanceOf(investor);
-    await migrationTarget.setMigrationSource(chain.lockedAccount.address, {
-      from: admin
+
+    async function migrateOne(ticket, investorAddress) {
+      const neumarks = ticket.mul(6.5);
+      // lock investor
+      await chain.commitment.investFor(investorAddress, ticket, neumarks, {
+        value: ticket,
+        from: investorAddress
+      });
+      const investorBalanceBefore = await chain.lockedAccount.balanceOf(
+        investorAddress
+      );
+      const assetBalanceSourceBefore = await assetToken.balanceOf(
+        chain.lockedAccount.address
+      );
+      await migrationTarget.setMigrationSource(chain.lockedAccount.address, {
+        from: admin
+      });
+      assert.equal(
+        await migrationTarget.getMigrationFrom(),
+        chain.lockedAccount.address,
+        "correct migration source set"
+      );
+      let tx = await chain.lockedAccount.enableMigration(
+        migrationTarget.address,
+        { from: admin }
+      );
+      let event = eventValue(tx, "MigrationEnabled");
+      expect(event).to.exist;
+      expect(event.args.target).to.be.equal(migrationTarget.address);
+      // migrate investor
+      tx = await chain.lockedAccount.migrate({ from: investorAddress });
+      event = eventValue(tx, "InvestorMigrated");
+      expect(event).to.exist;
+      expect(event.args.investor).to.be.equal(investorAddress);
+      expect(event.args.amount).to.be.bignumber.equal(ticket);
+      expect(event.args.neumarks).to.be.bignumber.equal(neumarks);
+      expect(event.args.unlockDate).to.be.bignumber.equal(
+        investorBalanceBefore[2]
+      );
+      // check invariants
+      expect(
+        await chain.lockedAccount.totalLockedAmount()
+      ).to.be.bignumber.equal(0);
+      expect(await migrationTarget.totalLockedAmount()).to.be.bignumber.equal(
+        ticket
+      );
+      expect(await chain.lockedAccount.totalInvestors()).to.be.bignumber.equal(
+        0
+      );
+      expect(await migrationTarget.totalInvestors()).to.be.bignumber.equal(1);
+      // check balance on old - no investor
+      const investorBalanceAfter = await chain.lockedAccount.balanceOf(
+        investorAddress
+      );
+      // unlockDate == 0: does not exit
+      expect(
+        investorBalanceAfter[2],
+        "unlockDate zeroed == no account"
+      ).to.be.bignumber.equal(0);
+      // check asset balance
+      const assetBalanceSourceAfter = await assetToken.balanceOf(
+        chain.lockedAccount.address
+      );
+      const assetBalanceTargetAfter = await assetToken.balanceOf(
+        migrationTarget.address
+      );
+      expect(assetBalanceSourceAfter).to.be.bignumber.eq(
+        assetBalanceSourceBefore.sub(ticket)
+      );
+      expect(assetBalanceTargetAfter).to.be.bignumber.eq(ticket);
+    }
+
+    async function enableReleaseAll() {
+      await migrationTarget.setController(admin, { from: admin });
+      await migrationTarget.controllerFailed({ from: admin });
+    }
+
+    async function withdrawAsset(investorAddress, amount) {
+      const initalBalance = await web3.eth.getBalance(investorAddress);
+      const tx = await assetToken.withdraw(amount, {
+        from: investorAddress,
+        gasPrice
+      });
+      const afterBalance = await web3.eth.getBalance(investorAddress);
+      const gasCost = gasPrice.mul(tx.receipt.gasUsed);
+      expect(afterBalance).to.be.bignumber.eq(
+        initalBalance.add(amount).sub(gasCost)
+      );
+    }
+
+    it("should migrate investor", async () => {
+      await migrateOne(chain.ether(1), investor);
     });
-    assert.equal(
-      await migrationTarget.getMigrationFrom(),
-      chain.lockedAccount.address,
-      "correct migration source set"
-    );
-    let tx = await chain.lockedAccount.enableMigration(
-      migrationTarget.address,
-      { from: admin }
-    );
-    let event = eventValue(tx, "MigrationEnabled");
-    expect(event).to.exist;
-    expect(event.args.target).to.be.equal(migrationTarget.address);
-    // migrate investor
-    tx = await chain.lockedAccount.migrate({ from: investor });
-    event = eventValue(tx, "InvestorMigrated");
-    expect(event).to.exist;
-    expect(event.args.investor).to.be.equal(investor);
-    expect(event.args.amount).to.be.bignumber.equal(ticket);
-    expect(event.args.neumarks).to.be.bignumber.equal(neumarks);
-    expect(event.args.unlockDate).to.be.bignumber.equal(investorBalance[2]);
-    // check invariants
-    expect(await chain.lockedAccount.totalLockedAmount()).to.be.bignumber.equal(
-      0
-    );
-    expect(await migrationTarget.totalLockedAmount()).to.be.bignumber.equal(
-      ticket
-    );
-    expect(await chain.lockedAccount.totalInvestors()).to.be.bignumber.equal(0);
-    expect(await migrationTarget.totalInvestors()).to.be.bignumber.equal(1);
-    // check balance on old - no investor
-    investorBalance = await chain.lockedAccount.balanceOf(investor);
-    // unlockDate == 0: does not exit
-    expect(
-      investorBalance[2],
-      "unlockDate zeroed == no account"
-    ).to.be.bignumber.equal(0);
+
+    it("should migrate investor then unlock and withdraw", async () => {
+      const ticket = chain.ether(1);
+      await migrateOne(ticket, investor);
+      await enableReleaseAll();
+      // no need to burn neumarks
+      await migrationTarget.unlock({ from: investor });
+      await withdrawAsset(investor, ticket);
+    });
+
+    it("migrate same investor twice should do nothing", async () => {
+      await migrateOne(chain.ether(1), investor);
+      const tx = await chain.lockedAccount.migrate({ from: investor });
+      expect(hasEvent(tx, "InvestorMigrated")).to.be.false;
+    });
+
+    it("migrate non existing investor should do nothing", async () => {
+      await migrateOne(chain.ether(1), investor);
+      const tx = await chain.lockedAccount.migrate({ from: investor2 });
+      expect(hasEvent(tx, "InvestorMigrated")).to.be.false;
+    });
+
+    it("enabling migration for a second time should throw", async () => {
+      await migrationTarget.setMigrationSource(chain.lockedAccount.address, {
+        from: admin
+      });
+      await chain.lockedAccount.enableMigration(migrationTarget.address, {
+        from: admin
+      });
+      // must throw
+      await expect(
+        chain.lockedAccount.enableMigration(migrationTarget.address)
+      ).to.be.rejectedWith(EvmError);
+    });
   }
-
-  it("should migrate investor", async () => {
-    await migrateOne();
-  });
-
-  it("migrate same investor twice should do nothing", async () => {
-    await migrateOne();
-    const tx = await chain.lockedAccount.migrate({ from: investor });
-    expect(hasEvent(tx, "InvestorMigrated")).to.be.false;
-  });
-
-  it("migrate non existing investor should do nothing", async () => {
-    await migrateOne();
-    const tx = await chain.lockedAccount.migrate({ from: investor2 });
-    expect(hasEvent(tx, "InvestorMigrated")).to.be.false;
-  });
-
-  it("enabling migration for a second time should throw", async () => {
-    await migrationTarget.setMigrationSource(chain.lockedAccount.address, {
-      from: admin
-    });
-    await chain.lockedAccount.enableMigration(migrationTarget.address, {
-      from: admin
-    });
-    // must throw
-    await expect(
-      chain.lockedAccount.enableMigration(migrationTarget.address)
-    ).to.be.rejectedWith(EvmError);
-  });
-});
+);


### PR DESCRIPTION
Important omission in LockedAccount migration (came out due increased test coverage):
Migration target didn't receive allowance to transfer investors' assets so only `Account` was transferred but not underlying asset.
This got fixed.