### PR TITLE
adds agreement structure to ico

### DIFF
--- a/contracts/AccessRoles.sol
+++ b/contracts/AccessRoles.sol
@@ -21,7 +21,6 @@ contract AccessRoles {
     bytes32 internal constant ROLE_NEUMARK_BURNER = 0x19ce331285f41739cd3362a3ec176edffe014311c0f8075834fdd19d6718e69f;
     bytes32 internal constant ROLE_SNAPSHOT_CREATOR = 0x08c1785afc57f933523bc52583a72ce9e19b2241354e04dd86f41f887e3d8174;
     bytes32 internal constant ROLE_TRANSFER_ADMIN = 0xb6527e944caca3d151b1f94e49ac5e223142694860743e66164720e034ec9b19;
-    bytes32 internal constant ROLE_TRANSFERER = 0x717f4dfc78f8be2df98de8d044e6a6668a3a6488162d21f64ac65d9415c2fafd;
 
     bytes32 internal constant ROLE_RECLAIMER = 0x0542bbd0c672578966dcc525b30aa16723bb042675554ac5b0362f86b6e97dc5;
 
@@ -30,6 +29,4 @@ contract AccessRoles {
 
     // allows to deposit EUR-T and allow addresses to send and receive EUR-T. keccak256("EurtDepositManager")
     bytes32 internal constant ROLE_EURT_DEPOSIT_MANAGER = 0x7c8ecdcba80ce87848d16ad77ef57cc196c208fc95c5638e4a48c681a34d4fe7;
-
-    //
 }

--- a/contracts/Commitment/Commitment.sol
+++ b/contracts/Commitment/Commitment.sol
@@ -87,8 +87,10 @@ contract Commitment is
     // NOTE: The order of of the investors matters when computing the reward.
     address[] private _whitelistInvestors;
 
+    // amount of Neumarks reserved for Ether whitelist investors
     uint256 private _whitelistEtherNmk;
 
+    // amount of Neumarks reserved for Euro whitelist investors
     uint256 private _whitelistEuroNmk;
 
     ////////////////////////

--- a/contracts/Commitment/Commitment.sol
+++ b/contracts/Commitment/Commitment.sol
@@ -477,8 +477,8 @@ contract Commitment is
         investorNmk = sub(totalNmk, platformNmk);
 
         // Issue Neumarks and distribute
-        assert(NEUMARK.transfer(msg.sender, investorNmk));
-        assert(NEUMARK.transfer(PLATFORM_WALLET, platformNmk));
+        NEUMARK.distributeNeumark(msg.sender, investorNmk);
+        NEUMARK.distributeNeumark(PLATFORM_WALLET, platformNmk);
 
         return (investorNmk, ticketNmk);
     }

--- a/contracts/Commitment/Commitment.sol
+++ b/contracts/Commitment/Commitment.sol
@@ -7,12 +7,14 @@ import '../Math.sol';
 import '../Neumark.sol';
 import './TimedStateMachine.sol';
 import "../AccessControl/AccessControlled.sol";
+import "../Agreement.sol";
 import "../Reclaimable.sol";
 
 
 // Consumes MCommitment
 contract Commitment is
     AccessControlled,
+    Agreement,
     TimedStateMachine,
     Reclaimable,
     Math
@@ -116,6 +118,7 @@ contract Commitment is
     /// _lockedAccount and _nemark
     function Commitment(
         IAccessPolicy accessPolicy,
+        IEthereumForkArbiter forkArbiter,
         int256 startDate,
         address platformWallet,
         Neumark neumark,
@@ -128,6 +131,7 @@ contract Commitment is
         uint256 ethEurFraction
     )
         AccessControlled(accessPolicy)
+        Agreement(accessPolicy, forkArbiter)
         TimedStateMachine(startDate)
     {
         require(platformWallet != 0x0);
@@ -204,6 +208,7 @@ contract Commitment is
         payable
         withTimedTransitions()
         onlyStates(State.Whitelist, State.Public)
+        acceptAgreement(msg.sender)
     {
         // Take with EtherToken allowance (if any)
         uint256 commitedWei = ETHER_TOKEN.allowance(msg.sender, this);
@@ -237,6 +242,7 @@ contract Commitment is
         external
         withTimedTransitions()
         onlyStates(State.Whitelist, State.Public)
+        acceptAgreement(msg.sender)
     {
         // Receive Euro tokens
         uint256 euroUlp = EURO_TOKEN.allowance(msg.sender, this);

--- a/contracts/Neumark.sol
+++ b/contracts/Neumark.sol
@@ -70,7 +70,7 @@ contract Neumark is
         NeumarkIssuanceCurve()
         Reclaimable()
     {
-        _transferEnabled = false;
+        _transferEnabled = true;
         _totalEuroUlps = 0;
     }
 
@@ -81,6 +81,7 @@ contract Neumark is
     function issueForEuro(uint256 euroUlps)
         public
         only(ROLE_NEUMARK_ISSUER)
+        acceptAgreement(msg.sender)
         returns (uint256)
     {
         require(_totalEuroUlps + euroUlps >= _totalEuroUlps);
@@ -96,7 +97,7 @@ contract Neumark is
         only(ROLE_NEUMARK_ISSUER)
         acceptAgreement(to)
     {
-        bool success = mTransfer(msg.sender, to, neumarkUlps);
+        bool success = transfer(to, neumarkUlps);
         require(success);
     }
 

--- a/contracts/Neumark.sol
+++ b/contracts/Neumark.sol
@@ -81,7 +81,6 @@ contract Neumark is
     function issueForEuro(uint256 euroUlps)
         public
         only(ROLE_NEUMARK_ISSUER)
-        acceptAgreement(msg.sender)
         returns (uint256)
     {
         require(_totalEuroUlps + euroUlps >= _totalEuroUlps);
@@ -90,6 +89,15 @@ contract Neumark is
         mGenerateTokens(msg.sender, neumarkUlps);
         LogNeumarksIssued(msg.sender, euroUlps, neumarkUlps);
         return neumarkUlps;
+    }
+
+    function distributeNeumark(address to, uint256 neumarkUlps)
+        public
+        only(ROLE_NEUMARK_ISSUER)
+        acceptAgreement(to)
+    {
+        bool success = mTransfer(msg.sender, to, neumarkUlps);
+        require(success);
     }
 
     function burnNeumark(uint256 neumarkUlps)
@@ -169,18 +177,7 @@ contract Neumark is
         acceptAgreement(from)
         returns (bool allow)
     {
-        // When enabled, anyone can
-        if (_transferEnabled) {
-            return true;
-        }
-
-        // When disabled, require ROLE_TRANSFERER
-        return accessPolicy().allowed(
-            msg.sender,
-            ROLE_TRANSFERER,
-            this,
-            msg.sig
-        );
+        return _transferEnabled;
     }
 
     function mOnApprove(

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -9,7 +9,7 @@ const EuroToken = artifacts.require("EuroToken");
 const Commitment = artifacts.require("Commitment");
 
 // Needs to match contracts/AccessControl/RoleBasedAccessControl.sol:TriState
-const TriState = {Unset: 0, Allow: 1, Deny: 2};
+const TriState = { Unset: 0, Allow: 1, Deny: 2 };
 const EVERYONE = "0x0";
 const GLOBAL = "0x0";
 const Q18 = web3.toBigNumber("10").pow(18);
@@ -23,7 +23,7 @@ const MIN_TICKET_EUR = web3.toBigNumber("300").mul(Q18);
 const ETH_EUR_FRACTION = web3.toBigNumber("300").mul(Q18);
 
 module.exports = function deployContracts(deployer, network, accounts) {
-  deployer.then(async() => {
+  deployer.then(async () => {
     const lockedAccountAdmin = accounts[1];
     const whitelistAdmin = accounts[2];
     const platformOperatorWallet = accounts[3];

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -9,7 +9,7 @@ const EuroToken = artifacts.require("EuroToken");
 const Commitment = artifacts.require("Commitment");
 
 // Needs to match contracts/AccessControl/RoleBasedAccessControl.sol:TriState
-const TriState = { Unset: 0, Allow: 1, Deny: 2 };
+const TriState = {Unset: 0, Allow: 1, Deny: 2};
 const EVERYONE = "0x0";
 const GLOBAL = "0x0";
 const Q18 = web3.toBigNumber("10").pow(18);
@@ -23,11 +23,12 @@ const MIN_TICKET_EUR = web3.toBigNumber("300").mul(Q18);
 const ETH_EUR_FRACTION = web3.toBigNumber("300").mul(Q18);
 
 module.exports = function deployContracts(deployer, network, accounts) {
-  deployer.then(async () => {
+  deployer.then(async() => {
     const lockedAccountAdmin = accounts[1];
     const whitelistAdmin = accounts[2];
     const platformOperatorWallet = accounts[3];
     const platformOperatorRepresentative = accounts[4];
+    const eurtDepositManager = accounts[5];
 
     console.log("AccessControl deployment...");
     await deployer.deploy(RoleBasedAccessControl);
@@ -79,6 +80,7 @@ module.exports = function deployContracts(deployer, network, accounts) {
     await deployer.deploy(
       Commitment,
       accessControl.address,
+      ethereumForkArbiter.address,
       START_DATE,
       platformOperatorWallet,
       neumark.address,
@@ -112,23 +114,11 @@ module.exports = function deployContracts(deployer, network, accounts) {
       TriState.Allow
     );
     await accessControl.setUserRole(
-      commitment.address,
-      web3.sha3("TransfersAdmin"),
-      neumark.address,
-      TriState.Allow
-    );
-    await accessControl.setUserRole(
       lockedAccountAdmin,
       web3.sha3("LockedAccountAdmin"),
       GLOBAL,
       TriState.Allow
     );
-    await etherLock.setController(commitment.address, {
-      from: lockedAccountAdmin
-    });
-    await euroLock.setController(commitment.address, {
-      from: lockedAccountAdmin
-    });
     await accessControl.setUserRole(
       whitelistAdmin,
       web3.sha3("WhitelistAdmin"),
@@ -138,7 +128,13 @@ module.exports = function deployContracts(deployer, network, accounts) {
     await accessControl.setUserRole(
       platformOperatorRepresentative,
       web3.sha3("PlatformOperatorRepresentative"),
-      neumark.address,
+      GLOBAL,
+      TriState.Allow
+    );
+    await accessControl.setUserRole(
+      eurtDepositManager,
+      web3.sha3("EurtDepositManager"),
+      euroToken.address,
       TriState.Allow
     );
     console.log("Amending agreements");
@@ -148,6 +144,32 @@ module.exports = function deployContracts(deployer, network, accounts) {
         from: platformOperatorRepresentative
       }
     );
+    await commitment.amendAgreement(
+      "ipfs:QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT",
+      {
+        from: platformOperatorRepresentative
+      }
+    );
+    console.log("Attaching Commitment to LockedAccounts");
+    await etherLock.setController(commitment.address, {
+      from: lockedAccountAdmin
+    });
+    await euroLock.setController(commitment.address, {
+      from: lockedAccountAdmin
+    });
+    console.log("EuroToken deposit permissions");
+    await euroToken.setAllowedTransferFrom(commitment.address, true, {
+      from: eurtDepositManager
+    });
+    await euroToken.setAllowedTransferTo(commitment.address, true, {
+      from: eurtDepositManager
+    });
+    await euroToken.setAllowedTransferTo(euroLock.address, true, {
+      from: eurtDepositManager
+    });
+    await euroToken.setAllowedTransferFrom(euroLock.address, true, {
+      from: eurtDepositManager
+    });
     console.log("Contracts deployed!");
 
     console.log("----------------------------------");

--- a/test/Commitment.js
+++ b/test/Commitment.js
@@ -86,6 +86,7 @@ contract(
       );
       commitment = await Commitment.new(
         rbac.address,
+        forkArbiter.address,
         startDate,
         platform,
         neumark.address,
@@ -104,10 +105,10 @@ contract(
         { subject: eurtDepositManager, role: roles.eurtDepositManager },
         { subject: commitment.address, role: roles.neumarkIssuer },
         { subject: commitment.address, role: roles.neumarkBurner },
-        { subject: commitment.address, role: roles.transferAdmin },
-        { subject: commitment.address, role: roles.transferer }
+        { subject: commitment.address, role: roles.transferAdmin }
       ]);
       await neumark.amendAgreement(AGREEMENT, { from: representative });
+      await commitment.amendAgreement(AGREEMENT, { from: representative });
       await etherLock.setController(commitment.address, {
         from: lockedAccountAdmin
       });

--- a/test/LockedAccount.js
+++ b/test/LockedAccount.js
@@ -613,8 +613,6 @@ contract(
         await increaseTime(moment.duration(dayInSeconds, "s"));
         // controller says yes
         await controller.succ();
-        // must enable token transfers
-        await neumark.enableTransfer(true);
       }
 
       async function allowToReclaim(account) {

--- a/test/Neumark.js
+++ b/test/Neumark.js
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import EvmError from "./helpers/EVMThrow";
 import { prettyPrintGasCost } from "./helpers/gasUtils";
 import { eventValue } from "./helpers/events";
 import createAccessPolicy from "./helpers/createAccessPolicy";
@@ -22,277 +23,348 @@ const AGREEMENT = "ipfs:QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT";
 const EUR_DECIMALS = new BigNumber(10).toPower(18);
 const NMK_DECIMALS = new BigNumber(10).toPower(18);
 
-contract("Neumark", accounts => {
-  let snapshot;
-  let rbac;
-  let forkArbiter;
-  let neumark;
+contract(
+  "Neumark",
+  ([deployer, other, platformRepresentative, transferAdmin, ...accounts]) => {
+    let snapshot;
+    let rbac;
+    let forkArbiter;
+    let neumark;
 
-  before(async () => {
-    rbac = await createAccessPolicy([
-      { subject: accounts[0], role: roles.transferAdmin },
-      { subject: accounts[0], role: roles.neumarkIssuer },
-      { subject: accounts[1], role: roles.neumarkIssuer },
-      { subject: accounts[2], role: roles.neumarkIssuer },
-      { subject: accounts[0], role: roles.neumarkBurner },
-      { subject: accounts[1], role: roles.neumarkBurner },
-      { subject: accounts[0], role: roles.platformOperatorRepresentative }
-    ]);
-    forkArbiter = await EthereumForkArbiter.new(rbac.address);
-    neumark = await Neumark.new(rbac.address, forkArbiter.address);
-    await neumark.amendAgreement(AGREEMENT);
-    snapshot = await saveBlockchain();
-  });
-
-  beforeEach(async () => {
-    await restoreBlockchain(snapshot);
-    snapshot = await saveBlockchain();
-  });
-
-  it("should deploy", async () => {
-    await prettyPrintGasCost("Neumark deploy", neumark);
-  });
-
-  it("should have agreement and fork arbiter", async () => {
-    const actualAgreement = await neumark.currentAgreement.call();
-    const actualForkArbiter = await neumark.ethereumForkArbiter.call();
-
-    expect(actualAgreement[2]).to.equal(AGREEMENT);
-    expect(actualForkArbiter).to.equal(forkArbiter.address);
-  });
-
-  it("should have name Neumark, symbol NMK and 18 decimals", async () => {
-    assert.equal(await neumark.name.call(), "Neumark");
-    assert.equal(await neumark.symbol.call(), "NMK");
-    assert.equal(await neumark.decimals.call(), 18);
-  });
-
-  it("should start at zero", async () => {
-    assert.equal(await neumark.totalSupply.call(), 0);
-    assert.equal(await neumark.balanceOf.call(accounts[0]), 0);
-  });
-
-  it("should issue Neumarks", async () => {
-    assert.equal((await neumark.totalEuroUlps.call()).valueOf(), 0);
-    assert.equal((await neumark.totalSupply.call()).valueOf(), 0);
-
-    const expectedr1EUR = EUR_DECIMALS.mul(100);
-    const r1 = await neumark.issueForEuro(expectedr1EUR, {
-      from: accounts[1]
+    before(async () => {
+      rbac = await createAccessPolicy([
+        { subject: transferAdmin, role: roles.transferAdmin },
+        { subject: accounts[1], role: roles.neumarkIssuer },
+        { subject: accounts[2], role: roles.neumarkIssuer },
+        { subject: accounts[0], role: roles.neumarkBurner },
+        { subject: accounts[1], role: roles.neumarkBurner },
+        {
+          subject: platformRepresentative,
+          role: roles.platformOperatorRepresentative
+        }
+      ]);
+      forkArbiter = await EthereumForkArbiter.new(rbac.address, {
+        from: deployer
+      });
+      neumark = await Neumark.new(rbac.address, forkArbiter.address, {
+        from: deployer
+      });
+      await neumark.amendAgreement(AGREEMENT, { from: platformRepresentative });
+      snapshot = await saveBlockchain();
     });
-    await prettyPrintGasCost("Issue", r1);
-    const expectedr1NMK = new web3.BigNumber("649999859166687009257");
-    const r1NMK = eventValue(r1, "LogNeumarksIssued", "neumarkUlp");
-    expect(r1NMK.sub(expectedr1NMK).abs()).to.be.bignumber.lessThan(2);
-    expectTransferEvent(r1, ZERO_ADDRESS, accounts[1], r1NMK);
-    expect(await neumark.totalEuroUlps.call()).to.be.bignumber.eq(
-      expectedr1EUR
-    );
-    expect(await neumark.totalSupply.call()).to.be.bignumber.eq(r1NMK);
-    expect(await neumark.balanceOf.call(accounts[1])).to.be.bignumber.eq(r1NMK);
 
-    const expectedr2EUR = EUR_DECIMALS.mul(900);
-    const r2 = await neumark.issueForEuro(expectedr2EUR, {
-      from: accounts[2]
+    beforeEach(async () => {
+      await restoreBlockchain(snapshot);
+      snapshot = await saveBlockchain();
     });
-    const expectedr2NMK = new web3.BigNumber("5849986057520322227964");
-    const expectedTotalNMK = new web3.BigNumber("6499985916687009237221");
-    const r2NMK = eventValue(r2, "LogNeumarksIssued", "neumarkUlp");
-    expect(r2NMK.sub(expectedr2NMK).abs()).to.be.bignumber.lessThan(2);
-    expectTransferEvent(r2, ZERO_ADDRESS, accounts[2], r2NMK);
-    expect(await neumark.totalEuroUlps.call()).to.be.bignumber.eq(
-      expectedr2EUR.add(expectedr1EUR)
-    );
-    expect(await neumark.totalSupply.call()).to.be.bignumber.eq(
-      expectedTotalNMK
-    );
-    expect(await neumark.balanceOf.call(accounts[2])).to.be.bignumber.eq(r2NMK);
-  });
 
-  it("should issue and then burn Neumarks", async () => {
-    // Issue Neumarks for 1 mln Euros
-    const euroUlps = EUR_DECIMALS.mul(1000000);
-    const r = await neumark.issueForEuro(euroUlps, { from: accounts[1] });
-    await prettyPrintGasCost("Issue", r);
-    const neumarkUlps = await neumark.balanceOf.call(accounts[1]);
-    const neumarks = neumarkUlps.div(NMK_DECIMALS).floor();
-
-    // Burn a third the Neumarks
-    const toBurn = neumarks.div(3).round();
-    const toBurnUlps = NMK_DECIMALS.mul(toBurn);
-    const burned = await neumark.burnNeumark(toBurnUlps, { from: accounts[1] });
-    await prettyPrintGasCost("Burn", burned);
-    expect(
-      (await neumark.balanceOf.call(accounts[1])).div(NMK_DECIMALS).floor()
-    ).to.be.bignumber.eq(neumarks.sub(toBurn));
-    const burnedNMK = eventValue(burned, "LogNeumarksBurned", "neumarkUlp");
-    expectTransferEvent(burned, accounts[1], ZERO_ADDRESS, burnedNMK);
-  });
-
-  it("should issue same amount in multiple issuances", async () => {
-    // 1 ether + 100 wei in eur
-    const eurRate = 218.1192809;
-    const euroUlps = EUR_DECIMALS.mul(1).add(100).mul(eurRate);
-    const totNMK = await neumark.cumulative(euroUlps);
-    // issue for 1 ether
-    const euro1EthUlps = EUR_DECIMALS.mul(1).mul(eurRate);
-    let tx = await neumark.issueForEuro(euro1EthUlps);
-    const p1NMK = eventValue(tx, "LogNeumarksIssued", "neumarkUlp");
-    // issue for 100 wei
-    tx = await neumark.issueForEuro(new BigNumber(100).mul(eurRate));
-    const p2NMK = eventValue(tx, "LogNeumarksIssued", "neumarkUlp");
-    expect(totNMK).to.be.bignumber.equal(p1NMK.plus(p2NMK));
-  });
-
-  it("should transfer Neumarks", async () => {
-    const from = accounts[1];
-    await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from });
-    const amount = await neumark.balanceOf.call(accounts[1]);
-    await neumark.enableTransfer(true);
-
-    const tx = await neumark.transfer(accounts[3], amount, { from });
-    const balance1 = await neumark.balanceOf.call(accounts[1]);
-    const balance3 = await neumark.balanceOf.call(accounts[3]);
-
-    await prettyPrintGasCost("Transfer", tx);
-    expect(amount).to.be.bignumber.not.equal(0);
-    expect(balance1).to.be.bignumber.equal(0);
-    expect(balance3).to.be.bignumber.equal(amount);
-  });
-
-  it("should accept agreement on issue Neumarks", async () => {
-    const from = accounts[1];
-    const tx = await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from });
-
-    const agreements = tx.logs
-      .filter(e => e.event === "LogAgreementAccepted")
-      .map(({ args: { accepter } }) => accepter);
-    expect(agreements).to.have.length(1);
-    expect(agreements).to.contain(from);
-    const isSigned = await neumark.isAgreementSignedBy.call(from);
-    expect(isSigned).to.be.true;
-  });
-
-  it("should accept agreement on transfer", async () => {
-    const issuer = accounts[0];
-    const from = accounts[2];
-    const to = accounts[3];
-    await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from: issuer });
-    const amount = await neumark.balanceOf.call(issuer);
-    await neumark.enableTransfer(true);
-    // 'from' address will not be passively signed up here
-    await neumark.transfer(from, amount, { from: issuer });
-
-    // 'from' is making first transaction over Neumark, this will sign it up
-    const tx = await neumark.transfer(to, amount, { from });
-    const agreements = tx.logs
-      .filter(e => e.event === "LogAgreementAccepted")
-      .map(({ args: { accepter } }) => accepter);
-    expect(agreements).to.have.length(1);
-    expect(agreements).to.contain(from);
-    const isFromSigned = await neumark.isAgreementSignedBy.call(from);
-    expect(isFromSigned).to.be.true;
-    // 'to' should not be passively signed
-    const isToSigned = await neumark.isAgreementSignedBy.call(to);
-    expect(isToSigned).to.be.false;
-  });
-
-  it("should accept agreement on approve", async () => {
-    const issuer = accounts[0];
-    const to = accounts[3];
-    await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from: issuer });
-    const amount = await neumark.balanceOf.call(issuer);
-    await neumark.enableTransfer(true);
-    // 'to' address will not be passively signed up here
-    await neumark.transfer(to, amount, { from: issuer });
-
-    // 'from' is making first transaction over Neumark, this will sign it up
-    const tx = await neumark.approve(accounts[1], amount, { from: to });
-    const agreements = tx.logs
-      .filter(e => e.event === "LogAgreementAccepted")
-      .map(({ args: { accepter } }) => accepter);
-    expect(agreements).to.have.length(1);
-    expect(agreements).to.contain(to);
-    const isToSigned = await neumark.isAgreementSignedBy.call(to);
-    expect(isToSigned).to.be.true;
-  });
-
-  it("should transfer Neumarks only when enabled", async () => {
-    const from = accounts[1];
-    await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from });
-    const amount = await neumark.balanceOf.call(accounts[1]);
-    await neumark.enableTransfer(false);
-
-    const tx = neumark.transfer(accounts[3], amount, { from });
-
-    await expect(tx).to.revert;
-  });
-
-  async function initNeumarkBalance(initialBalanceNmk) {
-    // crude way to get exact Nmk balance
-    await neumark.issueForEuro(initialBalanceNmk.mul(6.5).round(), {
-      from: accounts[1]
+    it("should deploy", async () => {
+      await prettyPrintGasCost("Neumark deploy", neumark);
     });
-    const balance = await neumark.balanceOf.call(accounts[1]);
-    await neumark.burnNeumark(balance.sub(initialBalanceNmk), {
-      from: accounts[1]
+
+    it("should have agreement and fork arbiter", async () => {
+      const actualAgreement = await neumark.currentAgreement.call();
+      const actualForkArbiter = await neumark.ethereumForkArbiter.call();
+
+      expect(actualAgreement[2]).to.equal(AGREEMENT);
+      expect(actualForkArbiter).to.equal(forkArbiter.address);
     });
-    // every ulp counts
-    const finalBalance = await neumark.balanceOf.call(accounts[1]);
-    expect(finalBalance).to.be.bignumber.eq(initialBalanceNmk);
-    await neumark.enableTransfer(true, { from: accounts[0] });
+
+    it("should have name Neumark, symbol NMK and 18 decimals", async () => {
+      assert.equal(await neumark.name.call(), "Neumark");
+      assert.equal(await neumark.symbol.call(), "NMK");
+      assert.equal(await neumark.decimals.call(), 18);
+    });
+
+    it("should have transfers enabled after deployment", async () => {
+      assert.equal(await neumark.transferEnabled.call(), true);
+    });
+
+    it("should start at zero", async () => {
+      assert.equal(await neumark.totalSupply.call(), 0);
+      assert.equal(await neumark.balanceOf.call(accounts[0]), 0);
+    });
+
+    it("should issue Neumarks", async () => {
+      assert.equal((await neumark.totalEuroUlps.call()).valueOf(), 0);
+      assert.equal((await neumark.totalSupply.call()).valueOf(), 0);
+
+      const expectedr1EUR = EUR_DECIMALS.mul(100);
+      const r1 = await neumark.issueForEuro(expectedr1EUR, {
+        from: accounts[1]
+      });
+      await prettyPrintGasCost("Issue", r1);
+      const expectedr1NMK = new web3.BigNumber("649999859166687009257");
+      const r1NMK = eventValue(r1, "LogNeumarksIssued", "neumarkUlp");
+      expect(r1NMK.sub(expectedr1NMK).abs()).to.be.bignumber.lessThan(2);
+      expectTransferEvent(r1, ZERO_ADDRESS, accounts[1], r1NMK);
+      expect(await neumark.totalEuroUlps.call()).to.be.bignumber.eq(
+        expectedr1EUR
+      );
+      expect(await neumark.totalSupply.call()).to.be.bignumber.eq(r1NMK);
+      expect(await neumark.balanceOf.call(accounts[1])).to.be.bignumber.eq(
+        r1NMK
+      );
+
+      const expectedr2EUR = EUR_DECIMALS.mul(900);
+      const r2 = await neumark.issueForEuro(expectedr2EUR, {
+        from: accounts[2]
+      });
+      const expectedr2NMK = new web3.BigNumber("5849986057520322227964");
+      const expectedTotalNMK = new web3.BigNumber("6499985916687009237221");
+      const r2NMK = eventValue(r2, "LogNeumarksIssued", "neumarkUlp");
+      expect(r2NMK.sub(expectedr2NMK).abs()).to.be.bignumber.lessThan(2);
+      expectTransferEvent(r2, ZERO_ADDRESS, accounts[2], r2NMK);
+      expect(await neumark.totalEuroUlps.call()).to.be.bignumber.eq(
+        expectedr2EUR.add(expectedr1EUR)
+      );
+      expect(await neumark.totalSupply.call()).to.be.bignumber.eq(
+        expectedTotalNMK
+      );
+      expect(await neumark.balanceOf.call(accounts[2])).to.be.bignumber.eq(
+        r2NMK
+      );
+    });
+
+    it("should issue and then burn Neumarks", async () => {
+      // Issue Neumarks for 1 mln Euros
+      const euroUlps = EUR_DECIMALS.mul(1000000);
+      const r = await neumark.issueForEuro(euroUlps, { from: accounts[1] });
+      await prettyPrintGasCost("Issue", r);
+      const neumarkUlps = await neumark.balanceOf.call(accounts[1]);
+      const neumarks = neumarkUlps.div(NMK_DECIMALS).floor();
+
+      // Burn a third the Neumarks
+      const toBurn = neumarks.div(3).round();
+      const toBurnUlps = NMK_DECIMALS.mul(toBurn);
+      const burned = await neumark.burnNeumark(toBurnUlps, {
+        from: accounts[1]
+      });
+      await prettyPrintGasCost("Burn", burned);
+      expect(
+        (await neumark.balanceOf.call(accounts[1])).div(NMK_DECIMALS).floor()
+      ).to.be.bignumber.eq(neumarks.sub(toBurn));
+      const burnedNMK = eventValue(burned, "LogNeumarksBurned", "neumarkUlp");
+      expectTransferEvent(burned, accounts[1], ZERO_ADDRESS, burnedNMK);
+    });
+
+    it("should issue same amount in multiple issuances", async () => {
+      // 1 ether + 100 wei in eur
+      const eurRate = 218.1192809;
+      const euroUlps = EUR_DECIMALS.mul(1).add(100).mul(eurRate);
+      const totNMK = await neumark.cumulative(euroUlps);
+      // issue for 1 ether
+      const euro1EthUlps = EUR_DECIMALS.mul(1).mul(eurRate);
+      let tx = await neumark.issueForEuro(euro1EthUlps, { from: accounts[1] });
+      const p1NMK = eventValue(tx, "LogNeumarksIssued", "neumarkUlp");
+      // issue for 100 wei
+      tx = await neumark.issueForEuro(new BigNumber(100).mul(eurRate), {
+        from: accounts[1]
+      });
+      const p2NMK = eventValue(tx, "LogNeumarksIssued", "neumarkUlp");
+      expect(totNMK).to.be.bignumber.equal(p1NMK.plus(p2NMK));
+    });
+
+    it("should reject to issue Neumark for not allowed address", async () => {
+      const euroUlps = EUR_DECIMALS.mul(1000000);
+      // replace 'other' with 'accounts[1]' for this test to fails
+      await expect(
+        neumark.issueForEuro(euroUlps, { from: other })
+      ).to.be.rejectedWith(EvmError);
+    });
+
+    it("should reject to distribute Neumark for not allowed address", async () => {
+      const euroUlps = EUR_DECIMALS.mul(1000000);
+      const totNMK = await neumark.cumulative(euroUlps);
+      await neumark.issueForEuro(euroUlps, { from: accounts[1] });
+      // comment this line for this test to fail ....
+      await neumark.transfer(other, totNMK, { from: accounts[1] });
+      // and replace 'other' with 'accounts[1]' for this test to fail
+      await expect(
+        neumark.distributeNeumark(accounts[2], totNMK, { from: other })
+      ).to.be.rejectedWith(EvmError);
+    });
+
+    it("should transfer Neumarks", async () => {
+      const from = accounts[1];
+      await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from });
+      const amount = await neumark.balanceOf.call(accounts[1]);
+
+      const tx = await neumark.transfer(accounts[3], amount, { from });
+      const balance1 = await neumark.balanceOf.call(accounts[1]);
+      const balance3 = await neumark.balanceOf.call(accounts[3]);
+
+      await prettyPrintGasCost("Transfer", tx);
+      expect(amount).to.be.bignumber.not.equal(0);
+      expect(balance1).to.be.bignumber.equal(0);
+      expect(balance3).to.be.bignumber.equal(amount);
+    });
+
+    it("should accept agreement on issue Neumarks", async () => {
+      const from = accounts[1];
+      const tx = await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from });
+
+      const agreements = tx.logs
+        .filter(e => e.event === "LogAgreementAccepted")
+        .map(({ args: { accepter } }) => accepter);
+      expect(agreements).to.have.length(1);
+      expect(agreements).to.contain(from);
+      const isSigned = await neumark.isAgreementSignedBy.call(from);
+      expect(isSigned).to.be.true;
+    });
+
+    it("should accept agreement on transfer", async () => {
+      const issuer = accounts[1];
+      const from = accounts[2];
+      const to = accounts[3];
+      await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from: issuer });
+      const amount = await neumark.balanceOf.call(issuer);
+      // 'from' address will not be passively signed up here
+      await neumark.transfer(from, amount, { from: issuer });
+
+      // 'from' is making first transaction over Neumark, this will sign it up
+      const tx = await neumark.transfer(to, amount, { from });
+      const agreements = tx.logs
+        .filter(e => e.event === "LogAgreementAccepted")
+        .map(({ args: { accepter } }) => accepter);
+      expect(agreements).to.have.length(1);
+      expect(agreements).to.contain(from);
+      const isFromSigned = await neumark.isAgreementSignedBy.call(from);
+      expect(isFromSigned).to.be.true;
+      // 'to' should not be passively signed
+      const isToSigned = await neumark.isAgreementSignedBy.call(to);
+      expect(isToSigned).to.be.false;
+    });
+
+    it("should accept agreement on distribute Neumarks", async () => {
+      const issuer = accounts[1];
+      const from = accounts[2];
+      await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from: issuer });
+      const amount = await neumark.balanceOf.call(issuer);
+
+      // 'from' address should be signed up here, this is how distribute differs from transfer
+      const tx = await neumark.distributeNeumark(from, amount, {
+        from: issuer
+      });
+      const agreements = tx.logs
+        .filter(e => e.event === "LogAgreementAccepted")
+        .map(({ args: { accepter } }) => accepter);
+      expect(agreements).to.have.length(1);
+      expect(agreements).to.contain(from);
+      const isFromSigned = await neumark.isAgreementSignedBy.call(from);
+      expect(isFromSigned).to.be.true;
+    });
+
+    it("should accept agreement on approve", async () => {
+      const issuer = accounts[1];
+      const to = accounts[3];
+      await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from: issuer });
+      const amount = await neumark.balanceOf.call(issuer);
+      // 'to' address will not be passively signed up here
+      await neumark.transfer(to, amount, { from: issuer });
+
+      // 'from' is making first transaction over Neumark, this will sign it up
+      const tx = await neumark.approve(accounts[1], amount, { from: to });
+      const agreements = tx.logs
+        .filter(e => e.event === "LogAgreementAccepted")
+        .map(({ args: { accepter } }) => accepter);
+      expect(agreements).to.have.length(1);
+      expect(agreements).to.contain(to);
+      const isToSigned = await neumark.isAgreementSignedBy.call(to);
+      expect(isToSigned).to.be.true;
+    });
+
+    it("should transfer Neumarks only when enabled", async () => {
+      const from = accounts[1];
+      await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from });
+      const amount = await neumark.balanceOf.call(accounts[1]);
+      await neumark.enableTransfer(false, { from: transferAdmin });
+
+      const tx = neumark.transfer(accounts[3], amount, { from });
+      await expect(tx).to.be.rejectedWith(EvmError);
+    });
+
+    it("should distribute Neumarks only when enabled", async () => {
+      const from = accounts[1];
+      await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from });
+      const amount = await neumark.balanceOf.call(accounts[1]);
+      // comment line below for this test to fail
+      await neumark.enableTransfer(false, { from: transferAdmin });
+
+      const tx = neumark.distributeNeumark(accounts[3], amount, { from });
+      await expect(tx).to.be.rejectedWith(EvmError);
+    });
+
+    async function initNeumarkBalance(initialBalanceNmk) {
+      // crude way to get exact Nmk balance
+      await neumark.issueForEuro(initialBalanceNmk.mul(6.5).round(), {
+        from: accounts[1]
+      });
+      const balance = await neumark.balanceOf.call(accounts[1]);
+      await neumark.burnNeumark(balance.sub(initialBalanceNmk), {
+        from: accounts[1]
+      });
+      // every ulp counts
+      const finalBalance = await neumark.balanceOf.call(accounts[1]);
+      expect(finalBalance).to.be.bignumber.eq(initialBalanceNmk);
+    }
+
+    describe("IBasicToken tests", () => {
+      const initialBalanceNmk = NMK_DECIMALS.mul(1128192.2791827).round();
+      const getToken = () => neumark;
+
+      beforeEach(async () => {
+        await initNeumarkBalance(initialBalanceNmk);
+      });
+
+      basicTokenTests(getToken, accounts[1], accounts[2], initialBalanceNmk);
+    });
+
+    describe("IERC20Allowance tests", () => {
+      const initialBalanceNmk = NMK_DECIMALS.mul(91279837.398827).round();
+      const getToken = () => neumark;
+
+      beforeEach(async () => {
+        await initNeumarkBalance(initialBalanceNmk);
+      });
+
+      standardTokenTests(
+        getToken,
+        accounts[1],
+        accounts[2],
+        accounts[3],
+        initialBalanceNmk
+      );
+    });
+
+    describe("IERC677Token tests", () => {
+      const initialBalanceNmk = NMK_DECIMALS.mul(91279837.398827).round();
+      const getToken = () => neumark;
+      let erc667cb;
+      const getTestErc667cb = () => erc667cb;
+
+      beforeEach(async () => {
+        await initNeumarkBalance(initialBalanceNmk);
+        erc667cb = await deployTestErc677Callback();
+      });
+
+      erc677TokenTests(
+        getToken,
+        getTestErc667cb,
+        accounts[1],
+        initialBalanceNmk
+      );
+    });
+
+    describe("IERC223Token tests", () => {
+      const initialBalanceNmk = NMK_DECIMALS.mul(91279837.398827).round();
+      const getToken = () => neumark;
+
+      beforeEach(async () => {
+        await initNeumarkBalance(initialBalanceNmk);
+      });
+
+      erc223TokenTests(getToken, accounts[1], accounts[2], initialBalanceNmk);
+    });
   }
-
-  describe("IBasicToken tests", () => {
-    const initialBalanceNmk = NMK_DECIMALS.mul(1128192.2791827).round();
-    const getToken = () => neumark;
-
-    beforeEach(async () => {
-      await initNeumarkBalance(initialBalanceNmk);
-    });
-
-    basicTokenTests(getToken, accounts[1], accounts[2], initialBalanceNmk);
-  });
-
-  describe("IERC20Allowance tests", () => {
-    const initialBalanceNmk = NMK_DECIMALS.mul(91279837.398827).round();
-    const getToken = () => neumark;
-
-    beforeEach(async () => {
-      await initNeumarkBalance(initialBalanceNmk);
-    });
-
-    standardTokenTests(
-      getToken,
-      accounts[1],
-      accounts[2],
-      accounts[3],
-      initialBalanceNmk
-    );
-  });
-
-  describe("IERC677Token tests", () => {
-    const initialBalanceNmk = NMK_DECIMALS.mul(91279837.398827).round();
-    const getToken = () => neumark;
-    let erc667cb;
-    const getTestErc667cb = () => erc667cb;
-
-    beforeEach(async () => {
-      await initNeumarkBalance(initialBalanceNmk);
-      erc667cb = await deployTestErc677Callback();
-    });
-
-    erc677TokenTests(getToken, getTestErc667cb, accounts[1], initialBalanceNmk);
-  });
-
-  describe("IERC223Token tests", () => {
-    const initialBalanceNmk = NMK_DECIMALS.mul(91279837.398827).round();
-    const getToken = () => neumark;
-
-    beforeEach(async () => {
-      await initNeumarkBalance(initialBalanceNmk);
-    });
-
-    erc223TokenTests(getToken, accounts[1], accounts[2], initialBalanceNmk);
-  });
-});
+);

--- a/test/helpers/roles.js
+++ b/test/helpers/roles.js
@@ -9,6 +9,5 @@ export default {
   snapshotCreator: web3.sha3("SnapshotCreator"),
   transferAdmin: web3.sha3("TransferAdmin"),
   whitelistAdmin: web3.sha3("WhitelistAdmin"),
-  eurtDepositManager: web3.sha3("EurtDepositManager"),
-  transferer: web3.sha3("Transferer")
+  eurtDepositManager: web3.sha3("EurtDepositManager")
 };


### PR DESCRIPTION
splits issuing Neumarks into
1. `issueForEuro` used by NEUMARK_ISSUER to itself, no agreements are signed
2. `function distributeNeumark(address to, uint256 neumarkUlps)` used by NEUMARK_ISSUER to distribute, agreement is signed for `to` address, regardless of transferEnabled
3. Adds `Agreement` to `Commitment`

if direction is OK I will continue with the tests and deployment update