### PR TITLE
adds user signature block number

### DIFF
--- a/contracts/Agreement.sol
+++ b/contracts/Agreement.sol
@@ -50,8 +50,11 @@ contract Agreement is
     // Mutable state
     ////////////////////////
 
+    // stores all amendments to the agreement, first amendment is the original
     SignedAgreement[] private _amendments;
-    mapping(address => bool) private _signatories;
+
+    // stores block numbers of all addresses that signed the agreement (signatory => block number)
+    mapping(address => uint256) private _signatories;
 
     ////////////////////////
     // Events
@@ -73,9 +76,9 @@ contract Agreement is
     /// @notice logs that agreement was accepted by platform user
     /// @dev intended to be added to functions that if used make 'accepter' origin to enter legally binding agreement
     modifier acceptAgreement(address accepter) {
-        if(!_signatories[accepter]) {
+        if(_signatories[accepter] == 0) {
             require(_amendments.length > 0);
-            _signatories[accepter] = true;
+            _signatories[accepter] = block.number;
             LogAgreementAccepted(accepter);
         }
         _;
@@ -159,10 +162,10 @@ contract Agreement is
         );
     }
 
-    function isAgreementSignedBy(address signatory)
+    function agreementSignedAtBlock(address signatory)
         public
         constant
-        returns (bool signed)
+        returns (uint256)
     {
         return _signatories[signatory];
     }

--- a/test/Agreement.js
+++ b/test/Agreement.js
@@ -66,9 +66,13 @@ contract(
       expect(event.args.accepter).to.eq(signer);
     }
 
-    async function expectAgreementAccepted(signer) {
-      const signed = await agreement.isAgreementSignedBy.call(signer);
-      expect(signed).to.be.true;
+    async function expectAgreementAccepted(signer, signTx) {
+      const signedAtBlock = await agreement.agreementSignedAtBlock.call(signer);
+      if (signTx) {
+        expect(signedAtBlock).to.be.bignumber.eq(signTx.receipt.blockNumber);
+      } else {
+        expect(signedAtBlock).to.be.bignumber.gt(0);
+      }
     }
 
     it("should amend agreement", async () => {
@@ -113,7 +117,7 @@ contract(
       await amendAgreement(agreementUri);
       const tx = await agreement.signMeUp({ from: signer1 });
       expectAgreementAcceptedEvent(tx, signer1);
-      await expectAgreementAccepted(signer1);
+      await expectAgreementAccepted(signer1, tx);
     });
 
     it("should sign agreement once", async () => {
@@ -142,10 +146,10 @@ contract(
       await amendAgreement(agreementUri);
       const tx1 = await agreement.signMeUp({ from: signer1 });
       expectAgreementAcceptedEvent(tx1, signer1);
-      await expectAgreementAccepted(signer1);
+      await expectAgreementAccepted(signer1, tx1);
       const tx2 = await agreement.signMeUpAgain({ from: signer2 });
       expectAgreementAcceptedEvent(tx2, signer2);
-      await expectAgreementAccepted(signer2);
+      await expectAgreementAccepted(signer2, tx2);
     });
 
     it("should reject to sign when no agreement", async () => {

--- a/test/Neumark.js
+++ b/test/Neumark.js
@@ -50,6 +50,15 @@ contract(
       await neumark.amendAgreement(AGREEMENT, { from: platformRepresentative });
     });
 
+    async function expectAgreementAccepted(signer, signTx) {
+      const signedAtBlock = await neumark.agreementSignedAtBlock.call(signer);
+      if (signTx) {
+        expect(signedAtBlock).to.be.bignumber.eq(signTx.receipt.blockNumber);
+      } else {
+        expect(signedAtBlock).to.be.bignumber.gt(0);
+      }
+    }
+
     it("should deploy", async () => {
       await prettyPrintGasCost("Neumark deploy", neumark);
     });
@@ -203,8 +212,7 @@ contract(
         .map(({ args: { accepter } }) => accepter);
       expect(agreements).to.have.length(1);
       expect(agreements).to.contain(from);
-      const isSigned = await neumark.isAgreementSignedBy.call(from);
-      expect(isSigned).to.be.true;
+      expectAgreementAccepted(from, tx);
     });
 
     it("should accept agreement on transfer", async () => {
@@ -223,11 +231,10 @@ contract(
         .map(({ args: { accepter } }) => accepter);
       expect(agreements).to.have.length(1);
       expect(agreements).to.contain(from);
-      const isFromSigned = await neumark.isAgreementSignedBy.call(from);
-      expect(isFromSigned).to.be.true;
+      expectAgreementAccepted(from, tx);
       // 'to' should not be passively signed
-      const isToSigned = await neumark.isAgreementSignedBy.call(to);
-      expect(isToSigned).to.be.false;
+      const toSignedAt = await neumark.agreementSignedAtBlock.call(to);
+      expect(toSignedAt).to.be.bignumber.eq(0);
     });
 
     it("should accept agreement on distribute Neumarks", async () => {
@@ -245,8 +252,7 @@ contract(
         .map(({ args: { accepter } }) => accepter);
       expect(agreements).to.have.length(1);
       expect(agreements).to.contain(from);
-      const isFromSigned = await neumark.isAgreementSignedBy.call(from);
-      expect(isFromSigned).to.be.true;
+      expectAgreementAccepted(from, tx);
     });
 
     it("should accept agreement on approve", async () => {
@@ -264,8 +270,7 @@ contract(
         .map(({ args: { accepter } }) => accepter);
       expect(agreements).to.have.length(1);
       expect(agreements).to.contain(to);
-      const isToSigned = await neumark.isAgreementSignedBy.call(to);
-      expect(isToSigned).to.be.true;
+      expectAgreementAccepted(to, tx);
     });
 
     it("should transfer Neumarks only when enabled", async () => {


### PR DESCRIPTION
Instead of simple bool, block numbers that carry agreement signing dates are stored in Agreement
tests updated accordingly