### PR TITLE
disables transfers during icbm

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Several accounts are required to deploy on `mainnet` due to many roles with spec
 |LOCKED ACCOUNT ADMIN|May attach controller, set fee disbursal pool and migration in Locked Account contract| PO Admin | LockedAccount |
 |WHITELIST ADMIN|May setup whitelist and abort Commitment contract with curve rollback| PO Admin | Commitment |
 |NEUMARK ISSUER|May issue (generate) Neumarks (only Commitment or ETOs contract may have this right)| N/A| Commitment |
-|TRANSFER ADMIN|May enable/disable transfers on Neumark| PO Admin | Neumark |
+|TRANSFER ADMIN|May enable/disable transfers on Neumark| (**Commitment** contract to enable trading after ICBM) | Neumark |
 |RECLAIMER|may reclaim tokens/ether from contracts| PO Admin | global role |
 |PLATFORM OPERATOR REPRESENTATIVE|Represents legally platform operator in case of forks and contracts with legal agreement attached| PO Management | global role |
 |EURT DEPOSIT MANAGER|Allows to deposit EUR-T and allow addresses to send and receive EUR-T | PO Admin | EuroToken |

--- a/contracts/Commitment/Commitment.sol
+++ b/contracts/Commitment/Commitment.sol
@@ -435,6 +435,9 @@ contract Commitment is
             // enable escape hatch and end locking funds phase
             ETHER_LOCK.controllerSucceeded();
             EURO_LOCK.controllerSucceeded();
+
+            // enable Neumark transfers
+            NEUMARK.enableTransfer(true);
         }
         // burn Neumarks after state change to prevent theoretical re-entry
         NEUMARK.burn(nmkToBurn);

--- a/contracts/Neumark.sol
+++ b/contracts/Neumark.sol
@@ -37,8 +37,10 @@ contract Neumark is
     // Mutable state
     ////////////////////////
 
-    bool private _transferEnabled;
+    // disable transfers when Neumark is created
+    bool private _transferEnabled = false;
 
+    // at which point on curve new Neumarks will be created, see NeumarkIssuanceCurve contract
     uint256 private _totalEurUlps;
 
     ////////////////////////

--- a/contracts/Neumark.sol
+++ b/contracts/Neumark.sol
@@ -195,7 +195,8 @@ contract Neumark is
         acceptAgreement(from)
         returns (bool allow)
     {
-        return _transferEnabled;
+        // must have transfer enabled or msg.sender is Neumark issuer
+        return _transferEnabled || accessPolicy().allowed(msg.sender, ROLE_NEUMARK_ISSUER, this, msg.sig);
     }
 
     function mOnApprove(

--- a/contracts/Neumark.sol
+++ b/contracts/Neumark.sol
@@ -83,15 +83,15 @@ contract Neumark is
         DailyAndSnapshotable(0)
         NeumarkIssuanceCurve()
         Reclaimable()
-    {
-        _transferEnabled = true;
-        _totalEurUlps = 0;
-    }
+    {}
 
     ////////////////////////
     // Public functions
     ////////////////////////
 
+    /// @notice issues new Neumarks to msg.sender with cost at current curve position
+    ///     moves curve position by euroUlps
+    ///     callable only by ROLE_NEUMARK_ISSUER
     function issueForEuro(uint256 euroUlps)
         public
         only(ROLE_NEUMARK_ISSUER)
@@ -106,15 +106,18 @@ contract Neumark is
         return neumarkUlps;
     }
 
+    /// @notice used by ROLE_NEUMARK_ISSUER to transer newly issued neumarks
+    ///     typically to the investor and platform operator
     function distribute(address to, uint256 neumarkUlps)
         public
         only(ROLE_NEUMARK_ISSUER)
         acceptAgreement(to)
     {
-        bool success = transfer(to, neumarkUlps);
-        require(success);
+        mTransfer(msg.sender, to, neumarkUlps);
     }
 
+    /// @notice msg.sender can burn their Neumarks, curve is rolled back using inverse
+    ///     curve. as a result cost of Neumark gets lower (reward is higher)
     function burn(uint256 neumarkUlps)
         public
         only(ROLE_NEUMARK_BURNER)

--- a/migrations/3_deploy_permissions.js
+++ b/migrations/3_deploy_permissions.js
@@ -23,18 +23,28 @@ module.exports = function deployContracts(deployer, network, accounts) {
     const commitment = await Commitment.deployed();
 
     console.log("Seting permissions");
+    // allow commitment contract to issue Neumarks
     await accessPolicy.setUserRole(
       commitment.address,
       web3.sha3("NeumarkIssuer"),
       neumark.address,
       TriState.Allow
     );
+    // allow commitment contract to enable Neumark trading after ICBM
+    await accessPolicy.setUserRole(
+      commitment.address,
+      web3.sha3("TransferAdmin"),
+      neumark.address,
+      TriState.Allow
+    );
+    // allow anyone to burn their neumarks
     await accessPolicy.setUserRole(
       EVERYONE,
       web3.sha3("NeumarkBurner"),
       neumark.address,
       TriState.Allow
     );
+
     await accessPolicy.setUserRole(
       CONFIG.addresses.LOCKED_ACCOUNT_ADMIN,
       web3.sha3("LockedAccountAdmin"),

--- a/test/Neumark.js
+++ b/test/Neumark.js
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import EvmError from "./helpers/EVMThrow";
 import { prettyPrintGasCost } from "./helpers/gasUtils";
 import { eventValue } from "./helpers/events";
+import { EVERYONE } from "./helpers/triState";
 import createAccessPolicy from "./helpers/createAccessPolicy";
 import roles from "./helpers/roles";
 import {
@@ -26,7 +27,17 @@ const NMK_DECIMALS = new BigNumber(10).toPower(18);
 
 contract(
   "Neumark",
-  ([deployer, other, platformRepresentative, transferAdmin, ...accounts]) => {
+  (
+    [
+      deployer,
+      other,
+      platformRepresentative,
+      transferAdmin,
+      issuer1,
+      issuer2,
+      ...accounts
+    ]
+  ) => {
     let rbap;
     let forkArbiter;
     let neumark;
@@ -35,10 +46,10 @@ contract(
       rbap = await createAccessPolicy([
         { subject: transferAdmin, role: roles.transferAdmin },
         { subject: deployer, role: roles.snapshotCreator },
-        { subject: accounts[1], role: roles.neumarkIssuer },
-        { subject: accounts[2], role: roles.neumarkIssuer },
-        { subject: accounts[0], role: roles.neumarkBurner },
-        { subject: accounts[1], role: roles.neumarkBurner },
+        { subject: issuer1, role: roles.neumarkIssuer },
+        { subject: issuer2, role: roles.neumarkIssuer },
+        { subject: EVERYONE, role: roles.neumarkBurner },
+        // { subject: issuer2, role: roles.neumarkBurner },
         {
           subject: platformRepresentative,
           role: roles.platformOperatorRepresentative
@@ -78,286 +89,313 @@ contract(
       expect(event.args.neumarkUlps).to.be.bignumber.equal(neumarkUlps);
     }
 
-    it("should deploy", async () => {
-      await prettyPrintGasCost("Neumark deploy", neumark);
-    });
-
-    it("should have agreement and fork arbiter", async () => {
-      const actualAgreement = await neumark.currentAgreement.call();
-      const actualForkArbiter = await neumark.ethereumForkArbiter.call();
-
-      expect(actualAgreement[2]).to.equal(AGREEMENT);
-      expect(actualForkArbiter).to.equal(forkArbiter.address);
-    });
-
-    it("should have name Neumark, symbol NMK and 18 decimals", async () => {
-      assert.equal(await neumark.name.call(), "Neumark");
-      assert.equal(await neumark.symbol.call(), "NMK");
-      assert.equal(await neumark.decimals.call(), 18);
-    });
-
-    it("should have curve parameters", async () => {
-      expect(await neumark.neumarkCap.call()).to.be.bignumber.eq(
-        NMK_DECIMALS.mul(1500000000)
-      );
-      expect(await neumark.initialRewardFraction.call()).to.be.bignumber.eq(
-        NMK_DECIMALS.mul(6.5)
-      );
-    });
-
-    it("should have transfers enabled after deployment", async () => {
-      assert.equal(await neumark.transferEnabled.call(), true);
-    });
-
-    it("should start at zero", async () => {
-      assert.equal(await neumark.totalSupply.call(), 0);
-      assert.equal(await neumark.balanceOf.call(accounts[0]), 0);
-    });
-
-    it("should issue Neumarks", async () => {
-      assert.equal((await neumark.totalEuroUlps.call()).valueOf(), 0);
-      assert.equal((await neumark.totalSupply.call()).valueOf(), 0);
-
-      const expectedr1EUR = EUR_DECIMALS.mul(100);
-      const r1 = await neumark.issueForEuro(expectedr1EUR, {
-        from: accounts[1]
-      });
-      await prettyPrintGasCost("Issue", r1);
-      const expectedr1NMK = new web3.BigNumber("649999859166687009257");
-      const r1NMK = eventValue(r1, "LogNeumarksIssued", "neumarkUlps");
-      expect(r1NMK.sub(expectedr1NMK).abs()).to.be.bignumber.lessThan(2);
-      expectTransferEvent(r1, ZERO_ADDRESS, accounts[1], r1NMK);
-      expectNeumarksIssuedEvent(r1, accounts[1], expectedr1EUR, r1NMK);
-      expect(await neumark.totalEuroUlps.call()).to.be.bignumber.eq(
-        expectedr1EUR
-      );
-      expect(await neumark.totalSupply.call()).to.be.bignumber.eq(r1NMK);
-      expect(await neumark.balanceOf.call(accounts[1])).to.be.bignumber.eq(
-        r1NMK
-      );
-
-      const expectedr2EUR = EUR_DECIMALS.mul(900);
-      const r2 = await neumark.issueForEuro(expectedr2EUR, {
-        from: accounts[2]
-      });
-      const expectedr2NMK = new web3.BigNumber("5849986057520322227964");
-      const expectedTotalNMK = new web3.BigNumber("6499985916687009237221");
-      const r2NMK = eventValue(r2, "LogNeumarksIssued", "neumarkUlps");
-      expect(r2NMK.sub(expectedr2NMK).abs()).to.be.bignumber.lessThan(2);
-      expectTransferEvent(r2, ZERO_ADDRESS, accounts[2], r2NMK);
-      expectNeumarksIssuedEvent(r2, accounts[2], expectedr2EUR, r2NMK);
-      expect(await neumark.totalEuroUlps.call()).to.be.bignumber.eq(
-        expectedr2EUR.add(expectedr1EUR)
-      );
-      expect(await neumark.totalSupply.call()).to.be.bignumber.eq(
-        expectedTotalNMK
-      );
-      expect(await neumark.balanceOf.call(accounts[2])).to.be.bignumber.eq(
-        r2NMK
-      );
-    });
-
-    it("should issue and then burn Neumarks", async () => {
-      // Issue Neumarks for 1 mln Euros
-      const euroUlps = EUR_DECIMALS.mul(1000000);
-      const r = await neumark.issueForEuro(euroUlps, { from: accounts[1] });
-      await prettyPrintGasCost("Issue", r);
-      const neumarkUlps = await neumark.balanceOf.call(accounts[1]);
-      const neumarks = neumarkUlps.div(NMK_DECIMALS).floor();
-      expectNeumarksIssuedEvent(r, accounts[1], euroUlps, neumarkUlps);
-
-      // Burn a third the Neumarks
-      const toBurn = neumarks.div(3).round();
-      const toBurnUlps = NMK_DECIMALS.mul(toBurn);
-      const burned = await neumark.burn(toBurnUlps, {
-        from: accounts[1]
-      });
-      await prettyPrintGasCost("Burn", burned);
-      expect(
-        (await neumark.balanceOf.call(accounts[1])).div(NMK_DECIMALS).floor()
-      ).to.be.bignumber.eq(neumarks.sub(toBurn));
-      const rollbackedEurUlps = eventValue(
-        burned,
-        "LogNeumarksBurned",
-        "euroUlps"
-      );
-      expectTransferEvent(burned, accounts[1], ZERO_ADDRESS, toBurnUlps);
-      expectNeumarksBurnedEvent(
-        burned,
-        accounts[1],
-        rollbackedEurUlps,
-        toBurnUlps
-      );
-    });
-
-    it("should issue same amount in multiple issuances", async () => {
-      // 1 ether + 100 wei in eur
-      const eurRate = 218.1192809;
-      const euroUlps = EUR_DECIMALS.mul(1)
-        .add(100)
-        .mul(eurRate);
-      const totNMK = await neumark.cumulative(euroUlps);
-      // issue for 1 ether
-      const euro1EthUlps = EUR_DECIMALS.mul(1).mul(eurRate);
-      let tx = await neumark.issueForEuro(euro1EthUlps, { from: accounts[1] });
-      const p1NMK = eventValue(tx, "LogNeumarksIssued", "neumarkUlps");
-      // issue for 100 wei
-      tx = await neumark.issueForEuro(new BigNumber(100).mul(eurRate), {
-        from: accounts[1]
-      });
-      const p2NMK = eventValue(tx, "LogNeumarksIssued", "neumarkUlps");
-      expect(totNMK).to.be.bignumber.equal(p1NMK.plus(p2NMK));
-    });
-
-    it("should reject to issue Neumark for not allowed address", async () => {
-      const euroUlps = EUR_DECIMALS.mul(1000000);
-      // replace 'other' with 'accounts[1]' for this test to fails
-      await expect(
-        neumark.issueForEuro(euroUlps, { from: other })
-      ).to.be.rejectedWith(EvmError);
-    });
-
-    it("should reject to distribute Neumark for not allowed address", async () => {
-      const euroUlps = EUR_DECIMALS.mul(1000000);
-      const totNMK = await neumark.cumulative(euroUlps);
-      await neumark.issueForEuro(euroUlps, { from: accounts[1] });
-      // comment this line for this test to fail ....
-      await neumark.transfer(other, totNMK, { from: accounts[1] });
-      // and replace 'other' with 'accounts[1]' for this test to fail
-      await expect(
-        neumark.distribute(accounts[2], totNMK, { from: other })
-      ).to.be.rejectedWith(EvmError);
-    });
-
-    it("should transfer Neumarks", async () => {
-      const from = accounts[1];
-      await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from });
-      const amount = await neumark.balanceOf.call(accounts[1]);
-
-      const tx = await neumark.transfer(accounts[3], amount, { from });
-      const balance1 = await neumark.balanceOf.call(accounts[1]);
-      const balance3 = await neumark.balanceOf.call(accounts[3]);
-
-      await prettyPrintGasCost("Transfer", tx);
-      expect(amount).to.be.bignumber.not.equal(0);
-      expect(balance1).to.be.bignumber.equal(0);
-      expect(balance3).to.be.bignumber.equal(amount);
-    });
-
-    it("should accept agreement on issue Neumarks", async () => {
-      const from = accounts[1];
-      const tx = await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from });
-
-      const agreements = tx.logs
-        .filter(e => e.event === "LogAgreementAccepted")
-        .map(({ args: { accepter } }) => accepter);
-      expect(agreements).to.have.length(1);
-      expect(agreements).to.contain(from);
-      expectAgreementAccepted(from, tx);
-    });
-
-    it("should accept agreement on transfer", async () => {
-      const issuer = accounts[1];
-      const from = accounts[2];
-      const to = accounts[3];
-      await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from: issuer });
-      const amount = await neumark.balanceOf.call(issuer);
-      // 'from' address will not be passively signed up here
-      await neumark.transfer(from, amount, { from: issuer });
-
-      // 'from' is making first transaction over Neumark, this will sign it up
-      const tx = await neumark.transfer(to, amount, { from });
-      const agreements = tx.logs
-        .filter(e => e.event === "LogAgreementAccepted")
-        .map(({ args: { accepter } }) => accepter);
-      expect(agreements).to.have.length(1);
-      expect(agreements).to.contain(from);
-      expectAgreementAccepted(from, tx);
-      // 'to' should not be passively signed
-      const toSignedAt = await neumark.agreementSignedAtBlock.call(to);
-      expect(toSignedAt).to.be.bignumber.eq(0);
-    });
-
-    it("should accept agreement on distribute Neumarks", async () => {
-      const issuer = accounts[1];
-      const from = accounts[2];
-      await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from: issuer });
-      const amount = await neumark.balanceOf.call(issuer);
-
-      // 'from' address should be signed up here, this is how distribute differs from transfer
-      const tx = await neumark.distribute(from, amount, {
-        from: issuer
-      });
-      const agreements = tx.logs
-        .filter(e => e.event === "LogAgreementAccepted")
-        .map(({ args: { accepter } }) => accepter);
-      expect(agreements).to.have.length(1);
-      expect(agreements).to.contain(from);
-      expectAgreementAccepted(from, tx);
-    });
-
-    it("should accept agreement on approve", async () => {
-      const issuer = accounts[1];
-      const to = accounts[3];
-      await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from: issuer });
-      const amount = await neumark.balanceOf.call(issuer);
-      // 'to' address will not be passively signed up here
-      await neumark.transfer(to, amount, { from: issuer });
-
-      // 'from' is making first transaction over Neumark, this will sign it up
-      const tx = await neumark.approve(accounts[1], amount, { from: to });
-      const agreements = tx.logs
-        .filter(e => e.event === "LogAgreementAccepted")
-        .map(({ args: { accepter } }) => accepter);
-      expect(agreements).to.have.length(1);
-      expect(agreements).to.contain(to);
-      expectAgreementAccepted(to, tx);
-    });
-
-    it("should transfer Neumarks only when enabled", async () => {
-      const from = accounts[1];
-      await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from });
-      const amount = await neumark.balanceOf.call(accounts[1]);
-      await neumark.enableTransfer(false, { from: transferAdmin });
-
-      const tx = neumark.transfer(accounts[3], amount, { from });
-      await expect(tx).to.be.rejectedWith(EvmError);
-    });
-
-    it("should distribute Neumarks only when enabled", async () => {
-      const from = accounts[1];
-      await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from });
-      const amount = await neumark.balanceOf.call(accounts[1]);
-      // comment line below for this test to fail
-      await neumark.enableTransfer(false, { from: transferAdmin });
-
-      const tx = neumark.distribute(accounts[3], amount, { from });
-      await expect(tx).to.be.rejectedWith(EvmError);
-    });
-
-    async function initNeumarkBalance(initialBalanceNmk) {
+    async function initNeumarkBalance(initialBalanceNmk, distributeTo) {
       // crude way to get exact Nmk balance
       await neumark.issueForEuro(initialBalanceNmk.mul(6.5).round(), {
-        from: accounts[1]
+        from: issuer1
       });
-      const balance = await neumark.balanceOf.call(accounts[1]);
+      const balance = await neumark.balanceOf.call(issuer1);
       await neumark.burn(balance.sub(initialBalanceNmk), {
-        from: accounts[1]
+        from: issuer1
       });
       // every ulp counts
-      const finalBalance = await neumark.balanceOf.call(accounts[1]);
+      const finalBalance = await neumark.balanceOf.call(issuer1);
       expect(finalBalance).to.be.bignumber.eq(initialBalanceNmk);
+      await neumark.distribute(distributeTo, initialBalanceNmk, {
+        from: issuer1
+      });
     }
+
+    describe("general tests", () => {
+      it("should deploy", async () => {
+        await prettyPrintGasCost("Neumark deploy", neumark);
+      });
+
+      it("should have agreement and fork arbiter", async () => {
+        const actualAgreement = await neumark.currentAgreement.call();
+        const actualForkArbiter = await neumark.ethereumForkArbiter.call();
+
+        expect(actualAgreement[2]).to.equal(AGREEMENT);
+        expect(actualForkArbiter).to.equal(forkArbiter.address);
+      });
+
+      it("should have name Neumark, symbol NMK and 18 decimals", async () => {
+        assert.equal(await neumark.name.call(), "Neumark");
+        assert.equal(await neumark.symbol.call(), "NMK");
+        assert.equal(await neumark.decimals.call(), 18);
+      });
+
+      it("should have curve parameters", async () => {
+        expect(await neumark.neumarkCap.call()).to.be.bignumber.eq(
+          NMK_DECIMALS.mul(1500000000)
+        );
+        expect(await neumark.initialRewardFraction.call()).to.be.bignumber.eq(
+          NMK_DECIMALS.mul(6.5)
+        );
+      });
+
+      it("should have transfers disabled after deployment", async () => {
+        assert.equal(await neumark.transferEnabled.call(), false);
+      });
+
+      it("should have transfers enabled for NEUMARK_ISSUER after deployment", async () => {
+        assert.equal(
+          await neumark.transferEnabled.call({ from: issuer1 }),
+          false
+        );
+      });
+
+      it("should reject to enable transfer without permission", async () => {
+        await expect(
+          neumark.enableTransfer(true, { from: other })
+        ).to.be.rejectedWith(EvmError);
+      });
+
+      it("should start at zero", async () => {
+        assert.equal(await neumark.totalSupply.call(), 0);
+        assert.equal(await neumark.balanceOf.call(accounts[0]), 0);
+      });
+
+      it("should issue Neumarks", async () => {
+        assert.equal((await neumark.totalEuroUlps.call()).valueOf(), 0);
+        assert.equal((await neumark.totalSupply.call()).valueOf(), 0);
+
+        const expectedr1EUR = EUR_DECIMALS.mul(100);
+        const r1 = await neumark.issueForEuro(expectedr1EUR, {
+          from: issuer1
+        });
+        await prettyPrintGasCost("Issue", r1);
+        const expectedr1NMK = new web3.BigNumber("649999859166687009257");
+        const r1NMK = eventValue(r1, "LogNeumarksIssued", "neumarkUlps");
+        expect(r1NMK.sub(expectedr1NMK).abs()).to.be.bignumber.lessThan(2);
+        expectTransferEvent(r1, ZERO_ADDRESS, issuer1, r1NMK);
+        expectNeumarksIssuedEvent(r1, issuer1, expectedr1EUR, r1NMK);
+        expect(await neumark.totalEuroUlps.call()).to.be.bignumber.eq(
+          expectedr1EUR
+        );
+        expect(await neumark.totalSupply.call()).to.be.bignumber.eq(r1NMK);
+        expect(await neumark.balanceOf.call(issuer1)).to.be.bignumber.eq(r1NMK);
+
+        const expectedr2EUR = EUR_DECIMALS.mul(900);
+        const r2 = await neumark.issueForEuro(expectedr2EUR, {
+          from: issuer2
+        });
+        const expectedr2NMK = new web3.BigNumber("5849986057520322227964");
+        const expectedTotalNMK = new web3.BigNumber("6499985916687009237221");
+        const r2NMK = eventValue(r2, "LogNeumarksIssued", "neumarkUlps");
+        expect(r2NMK.sub(expectedr2NMK).abs()).to.be.bignumber.lessThan(2);
+        expectTransferEvent(r2, ZERO_ADDRESS, issuer2, r2NMK);
+        expectNeumarksIssuedEvent(r2, issuer2, expectedr2EUR, r2NMK);
+        expect(await neumark.totalEuroUlps.call()).to.be.bignumber.eq(
+          expectedr2EUR.add(expectedr1EUR)
+        );
+        expect(await neumark.totalSupply.call()).to.be.bignumber.eq(
+          expectedTotalNMK
+        );
+        expect(await neumark.balanceOf.call(issuer2)).to.be.bignumber.eq(r2NMK);
+      });
+
+      it("should issue and then burn Neumarks", async () => {
+        // Issue Neumarks for 1 mln Euros
+        const euroUlps = EUR_DECIMALS.mul(1000000);
+        const r = await neumark.issueForEuro(euroUlps, { from: issuer1 });
+        await prettyPrintGasCost("Issue", r);
+        const neumarkUlps = await neumark.balanceOf.call(issuer1);
+        const neumarks = neumarkUlps.div(NMK_DECIMALS).floor();
+        expectNeumarksIssuedEvent(r, issuer1, euroUlps, neumarkUlps);
+
+        // Burn a third the Neumarks
+        const toBurn = neumarks.div(3).round();
+        const toBurnUlps = NMK_DECIMALS.mul(toBurn);
+        const burned = await neumark.burn(toBurnUlps, {
+          from: issuer1
+        });
+        await prettyPrintGasCost("Burn", burned);
+        expect(
+          (await neumark.balanceOf.call(issuer1)).div(NMK_DECIMALS).floor()
+        ).to.be.bignumber.eq(neumarks.sub(toBurn));
+        const rollbackedEurUlps = eventValue(
+          burned,
+          "LogNeumarksBurned",
+          "euroUlps"
+        );
+        expectTransferEvent(burned, issuer1, ZERO_ADDRESS, toBurnUlps);
+        expectNeumarksBurnedEvent(
+          burned,
+          issuer1,
+          rollbackedEurUlps,
+          toBurnUlps
+        );
+      });
+
+      it("should issue same amount in multiple issuances", async () => {
+        // 1 ether + 100 wei in eur
+        const eurRate = 218.1192809;
+        const euroUlps = EUR_DECIMALS.mul(1)
+          .add(100)
+          .mul(eurRate);
+        const totNMK = await neumark.cumulative(euroUlps);
+        // issue for 1 ether
+        const euro1EthUlps = EUR_DECIMALS.mul(1).mul(eurRate);
+        let tx = await neumark.issueForEuro(euro1EthUlps, { from: issuer1 });
+        const p1NMK = eventValue(tx, "LogNeumarksIssued", "neumarkUlps");
+        // issue for 100 wei
+        tx = await neumark.issueForEuro(new BigNumber(100).mul(eurRate), {
+          from: issuer1
+        });
+        const p2NMK = eventValue(tx, "LogNeumarksIssued", "neumarkUlps");
+        expect(totNMK).to.be.bignumber.equal(p1NMK.plus(p2NMK));
+      });
+
+      it("should reject to issue Neumark for not allowed address", async () => {
+        const euroUlps = EUR_DECIMALS.mul(1000000);
+        // replace 'other' with 'issuer1' for this test to fails
+        await expect(
+          neumark.issueForEuro(euroUlps, { from: other })
+        ).to.be.rejectedWith(EvmError);
+      });
+
+      it("should reject to distribute Neumark when called without permission", async () => {
+        const euroUlps = EUR_DECIMALS.mul(1000000);
+        const totNMK = await neumark.cumulative(euroUlps);
+        await neumark.issueForEuro(euroUlps, { from: issuer1 });
+        // comment this line for this test to fail ....
+        await neumark.distribute(other, totNMK, { from: issuer1 });
+        // and replace 'other' with 'issuer1' for this test to fail
+        await expect(
+          neumark.distribute(accounts[0], totNMK, { from: other })
+        ).to.be.rejectedWith(EvmError);
+      });
+
+      it("should transfer Neumarks", async () => {
+        await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from: issuer1 });
+        const amount = await neumark.balanceOf.call(issuer1);
+
+        await neumark.distribute(accounts[0], amount, { from: issuer1 });
+        // enable transfers as neumark is created without transfers enabled
+        await neumark.enableTransfer(true, { from: transferAdmin });
+
+        const tx = await neumark.transfer(accounts[1], amount, {
+          from: accounts[0]
+        });
+        await prettyPrintGasCost("Transfer", tx);
+
+        const balance0 = await neumark.balanceOf.call(accounts[0]);
+        const balance1 = await neumark.balanceOf.call(accounts[1]);
+        expect(amount).to.be.bignumber.not.equal(0);
+        expect(balance0).to.be.bignumber.equal(0);
+        expect(balance1).to.be.bignumber.equal(amount);
+      });
+
+      it("should accept agreement on issue Neumarks", async () => {
+        const tx = await neumark.issueForEuro(EUR_DECIMALS.mul(100), {
+          from: issuer1
+        });
+
+        const agreements = tx.logs
+          .filter(e => e.event === "LogAgreementAccepted")
+          .map(({ args: { accepter } }) => accepter);
+
+        expect(agreements).to.have.length(1);
+        expect(agreements).to.contain(issuer1);
+        expectAgreementAccepted(issuer1, tx);
+      });
+
+      it("should accept agreement on transfer", async () => {
+        const from = accounts[0];
+        const to = accounts[1];
+        await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from: issuer1 });
+        const amount = await neumark.balanceOf.call(issuer1);
+        await neumark.enableTransfer(true, { from: transferAdmin });
+        // 'from' address will not be passively signed up here (as transfer was used, not distribute)
+        await neumark.transfer(from, amount, { from: issuer1 });
+
+        // 'from' is making first transaction over Neumark, this will sign it up
+        const tx = await neumark.transfer(to, amount, { from });
+
+        const agreements = tx.logs
+          .filter(e => e.event === "LogAgreementAccepted")
+          .map(({ args: { accepter } }) => accepter);
+
+        expect(agreements).to.have.length(1);
+        expect(agreements).to.contain(from);
+        expectAgreementAccepted(from, tx);
+        // 'to' should not be passively signed
+        const toSignedAt = await neumark.agreementSignedAtBlock.call(to);
+        expect(toSignedAt).to.be.bignumber.eq(0);
+      });
+
+      it("should accept agreement on distribute Neumarks", async () => {
+        const from = accounts[0];
+        await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from: issuer1 });
+        const amount = await neumark.balanceOf.call(issuer1);
+
+        // 'from' address should be signed up here, this is how distribute differs from transfer
+        const tx = await neumark.distribute(from, amount, {
+          from: issuer1
+        });
+        const agreements = tx.logs
+          .filter(e => e.event === "LogAgreementAccepted")
+          .map(({ args: { accepter } }) => accepter);
+
+        expect(agreements).to.have.length(1);
+        expect(agreements).to.contain(from);
+        expectAgreementAccepted(from, tx);
+      });
+
+      it("should accept agreement on approve", async () => {
+        const to = accounts[0];
+        await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from: issuer1 });
+        const amount = await neumark.balanceOf.call(issuer1);
+        // 'to' address will not be passively signed up here (transfer used, not distribute)
+        await neumark.transfer(to, amount, { from: issuer1 });
+
+        // 'to' is making first transaction over Neumark, this will sign it up
+        const tx = await neumark.approve(issuer1, amount, { from: to });
+
+        const agreements = tx.logs
+          .filter(e => e.event === "LogAgreementAccepted")
+          .map(({ args: { accepter } }) => accepter);
+
+        expect(agreements).to.have.length(1);
+        expect(agreements).to.contain(to);
+        expectAgreementAccepted(to, tx);
+      });
+
+      it("should reject to transfer Neumarks when transfers disabled", async () => {
+        const investor = accounts[0];
+        const investor2 = accounts[1];
+        await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from: issuer1 });
+        const amount = await neumark.balanceOf.call(issuer1);
+        await neumark.distribute(investor, amount, { from: issuer1 });
+        await neumark.enableTransfer(false, { from: transferAdmin });
+
+        const tx = neumark.transfer(investor2, amount, { from: investor });
+        await expect(tx).to.be.rejectedWith(EvmError);
+      });
+
+      it("should distribute Neumarks when transfers disabled", async () => {
+        await neumark.issueForEuro(EUR_DECIMALS.mul(100), { from: issuer1 });
+        const amount = await neumark.balanceOf.call(issuer1);
+        await neumark.enableTransfer(false, { from: transferAdmin });
+
+        await neumark.distribute(accounts[0], amount, { from: issuer1 });
+        const account0Balance = await neumark.balanceOf.call(accounts[0]);
+        expect(account0Balance).to.be.bignumber.eq(amount);
+      });
+    });
 
     describe("IBasicToken tests", () => {
       const initialBalanceNmk = NMK_DECIMALS.mul(1128192.2791827).round();
       const getToken = () => neumark;
 
       beforeEach(async () => {
-        await initNeumarkBalance(initialBalanceNmk);
+        await initNeumarkBalance(initialBalanceNmk, accounts[0]);
+        // enable transfers for token tests
+        await neumark.enableTransfer(true, { from: transferAdmin });
       });
 
-      basicTokenTests(getToken, accounts[1], accounts[2], initialBalanceNmk);
+      basicTokenTests(getToken, accounts[0], accounts[1], initialBalanceNmk);
     });
 
     describe("IERC20Allowance tests", () => {
@@ -365,14 +403,16 @@ contract(
       const getToken = () => neumark;
 
       beforeEach(async () => {
-        await initNeumarkBalance(initialBalanceNmk);
+        await initNeumarkBalance(initialBalanceNmk, accounts[0]);
+        // enable transfers for token tests
+        await neumark.enableTransfer(true, { from: transferAdmin });
       });
 
       standardTokenTests(
         getToken,
+        accounts[0],
         accounts[1],
         accounts[2],
-        accounts[3],
         initialBalanceNmk
       );
     });
@@ -384,14 +424,16 @@ contract(
       const getTestErc667cb = () => erc667cb;
 
       beforeEach(async () => {
-        await initNeumarkBalance(initialBalanceNmk);
+        await initNeumarkBalance(initialBalanceNmk, accounts[0]);
         erc667cb = await deployTestErc677Callback();
+        // enable transfers for token tests
+        await neumark.enableTransfer(true, { from: transferAdmin });
       });
 
       erc677TokenTests(
         getToken,
         getTestErc667cb,
-        accounts[1],
+        accounts[0],
         initialBalanceNmk
       );
     });
@@ -401,10 +443,12 @@ contract(
       const getToken = () => neumark;
 
       beforeEach(async () => {
-        await initNeumarkBalance(initialBalanceNmk);
+        await initNeumarkBalance(initialBalanceNmk, accounts[0]);
+        // enable transfers for token tests
+        await neumark.enableTransfer(true, { from: transferAdmin });
       });
 
-      erc223TokenTests(getToken, accounts[1], accounts[2], initialBalanceNmk);
+      erc223TokenTests(getToken, accounts[0], accounts[1], initialBalanceNmk);
     });
 
     describe("ITokenSnapshots tests", () => {
@@ -417,6 +461,10 @@ contract(
 
       const createClone = async (parentToken, parentSnapshotId) =>
         TestSnapshotToken.new(parentToken.address, parentSnapshotId);
+
+      beforeEach(async () => {
+        await neumark.enableTransfer(true, { from: transferAdmin });
+      });
 
       snapshotTokenTests(
         getToken,

--- a/test/SnapshotToken.js
+++ b/test/SnapshotToken.js
@@ -48,6 +48,26 @@ contract("TestSnapshotToken", ([owner, owner2, broker]) => {
         ).to.be.rejectedWith(EvmError);
       });
 
+      it("should ERC223 transfer when transfer enabled", async () => {
+        const supply = new web3.BigNumber(88172891);
+        await token.deposit(supply, { from: owner });
+        await token.enableTransfers(true);
+        await token.transfer["address,uint256,bytes"](owner2, 18281, "", {
+          from: owner
+        });
+      });
+
+      it("should ERC223 reject transfer when transfer disabled", async () => {
+        const supply = new web3.BigNumber(88172891);
+        await token.deposit(supply, { from: owner });
+        await token.enableTransfers(false);
+        await expect(
+          token.transfer["address,uint256,bytes"](owner2, 18281, "", {
+            from: owner
+          })
+        ).to.be.rejectedWith(EvmError);
+      });
+
       it("should approve when approve enabled", async () => {
         await token.enableApprovals(true);
         await token.approve(broker, 18281, { from: owner });
@@ -59,13 +79,14 @@ contract("TestSnapshotToken", ([owner, owner2, broker]) => {
           token.approve(broker, 18281, { from: owner })
         ).to.be.rejectedWith(EvmError);
       });
+    });
 
-      it("should call currentSnapshotId without transaction", async () => {
-        const initialSnapshotId = await token.currentSnapshotId.call();
-        await token.createSnapshot.call();
-        const snapshotId = await token.currentSnapshotId.call();
-        expect(snapshotId).to.be.bignumber.eq(initialSnapshotId);
-      });
+    it("should call currentSnapshotId without transaction", async () => {
+      const token = getToken();
+      const initialSnapshotId = await token.currentSnapshotId.call();
+      await token.createSnapshot.call();
+      const snapshotId = await token.currentSnapshotId.call();
+      expect(snapshotId).to.be.bignumber.eq(initialSnapshotId);
     });
 
     snapshotTokenTests(


### PR DESCRIPTION
Neumark is created with transfers disabled, transfers are enabled after ICBM ends by Commitment smart contract.
This involves setting up permissions for Commitment contract to do it
Rationale: allowing secondary trading may result in market price below/above creation price which may disrupt ICBM process
Drawbacks: Commitment contract must be able to distribute Neumarks so it needs a form of transfer. It happens via distribute function of Neumarks, where NEUMARK_ISSUER has transfer permission.